### PR TITLE
Add CLI for managing keys and enhance user certificates

### DIFF
--- a/lib/mix/nerves_hub/shell.ex
+++ b/lib/mix/nerves_hub/shell.ex
@@ -19,7 +19,7 @@ defmodule Mix.NervesHubCLI.Shell do
     Mix.shell().yes?(output)
   end
 
-  def request_auth(prompt \\ "Local password:") do
+  def request_auth(prompt \\ "Local user password:") do
     password = password_get(prompt)
 
     case NervesHubCLI.User.auth(password) do

--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -1,6 +1,4 @@
 defmodule Mix.NervesHubCLI.Utils do
-  alias Mix.NervesHubCLI.Shell
-
   def default_product do
     config()[:app]
   end
@@ -48,6 +46,10 @@ defmodule Mix.NervesHubCLI.Utils do
       {:ok, metadata_item} -> metadata_item
       {:error, :not_found} -> default
     end
+  end
+
+  def stringify(map) when is_map(map) do
+    for {key, val} <- map, do: {to_string(key), val}, into: %{}
   end
 
   defp config() do

--- a/lib/mix/tasks/nerves_hub.deployment.ex
+++ b/lib/mix/tasks/nerves_hub.deployment.ex
@@ -61,6 +61,16 @@ defmodule Mix.Tasks.NervesHub.Deployment do
     end
   end
 
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments
+
+    Usage:
+      mix nerves_hub.deployment list
+      mix nerves_hub.deployment update [deployment_name] [key] [value]
+    """)
+  end
+
   def list(product) do
     auth = Shell.request_auth()
 
@@ -137,15 +147,5 @@ defmodule Mix.Tasks.NervesHub.Deployment do
     """
     tags: [#{Enum.join(tags, ", ")}]
     """
-  end
-
-  def render_help() do
-    Shell.raise("""
-    Invalid arguments
-
-    Usage:
-      mix nerves_hub.deployment list
-      mix nerves_hub.deployment update [deployment_name] [key] [value]
-    """)
   end
 end

--- a/lib/mix/tasks/nerves_hub.firmware.ex
+++ b/lib/mix/tasks/nerves_hub.firmware.ex
@@ -150,8 +150,8 @@ defmodule Mix.Tasks.NervesHub.Firmware do
     auth = Shell.request_auth()
 
     case API.Firmware.delete(uuid, auth) do
-      {:ok, %{"data" => %{}}} ->
-        Shell.info("Firmware published successfully")
+      {:ok, ""} ->
+        Shell.info("Firmware deleted successfully")
 
       error ->
         Shell.error("Failed to delete firmware \nreason: #{inspect(error)}")

--- a/lib/mix/tasks/nerves_hub.key.ex
+++ b/lib/mix/tasks/nerves_hub.key.ex
@@ -1,0 +1,195 @@
+defmodule Mix.Tasks.NervesHub.Key do
+  use Mix.Task
+
+  import Mix.NervesHubCLI.Utils
+  alias NervesHubCLI.API
+  alias Mix.NervesHubCLI.Shell
+
+  @shortdoc "Manages your NervesHub keys"
+
+  @moduledoc """
+  Manage your NervesHub keys.
+
+  ## list
+
+    mix nerves_hub.key list
+
+  ### Command line options
+
+    * `--local` - (Optional) Perform the operation only locally
+      defaults to `false` which will perform both local and remote operations
+
+  ## create
+
+  Create a new fwup key pair with the specified name.
+
+    mix nerves_hub.key create [name]
+
+  ### Command line options
+
+    * `--local` - (Optional) Perform the operation only locally
+      defaults to `false` which will perform both local and remote operations
+
+  ## delete
+
+  Delete the key with the specified name.
+
+    mix nerves_hub.key create [name]
+
+  ### Command line options
+
+    * `--local` - (Optional) Perform the operation only locally
+      defaults to `false` which will perform both local and remote operations
+  """
+
+  @switches [
+    local: :boolean
+  ]
+
+  def run(args) do
+    Application.ensure_all_started(:nerves_hub_cli)
+
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    case args do
+      ["list"] ->
+        list(opts)
+
+      ["create", name] ->
+        create(name, opts)
+
+      ["delete", name] ->
+        delete(name, opts)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments
+
+    Usage:
+      mix nerves_hub.key list
+    """)
+  end
+
+  def list(opts) do
+    if Keyword.get(opts, :local, false) do
+      list_local()
+    else
+      list_remote()
+    end
+  end
+
+  def list_local() do
+    NervesHubCLI.Key.local_keys()
+    |> Enum.map(&stringify/1)
+    |> render_keys()
+  end
+
+  def list_remote() do
+    auth = Shell.request_auth()
+
+    case API.Key.list(auth) do
+      {:ok, %{"data" => keys}} ->
+        render_keys(keys)
+
+      error ->
+        Shell.info("Failed to list keys \nreason: #{inspect(error)}")
+    end
+  end
+
+  def create(name, opts) do
+    if NervesHubCLI.Key.exists?(name) do
+      Shell.raise("The key #{name} already exists, aborting")
+    else
+      if Keyword.get(opts, :local, false) do
+        with {:ok, key} <- create_local(name) do
+          render_key(key)
+        else
+          error ->
+            Shell.render_error(error)
+        end
+      else
+        with {:ok, key} <- create_local(name),
+             {:ok, %{"data" => key}} <- create_remote(name, key) do
+          render_key(key)
+        else
+          error ->
+            Shell.render_error(error)
+        end
+      end
+    end
+  end
+
+  def delete(name, opts) do
+    if Mix.shell().yes?("Delete Key #{name}?") do
+      if Keyword.get(opts, :local, false) do
+        delete_local(name)
+      else
+        with {:ok, ""} <- delete_remote(name),
+             :ok <- delete_local(name) do
+          :ok
+        else
+          error ->
+            Shell.render_error(error)
+        end
+      end
+    end
+  end
+
+  def delete_remote(name) do
+    auth = Shell.request_auth()
+    Shell.info("Deleting remote key #{name}")
+    API.Key.delete(name, auth)
+  end
+
+  # TODO handle file not found
+  def delete_local(name) do
+    Shell.info("Deleting local key #{name}")
+    NervesHubCLI.Key.delete(name)
+  end
+
+  defp create_local(name) do
+    Shell.info("\nPlease enter a local password you wish to use to encrypt private key")
+    key_password = Shell.password_get("Local key password:")
+
+    with {:ok, public_key_file, _private_key_file} = NervesHubCLI.Key.create(name, key_password),
+         {:ok, public_key} <- File.read(public_key_file) do
+      {:ok, public_key}
+    end
+  end
+
+  defp create_remote(name, key) do
+    auth = Shell.request_auth()
+    API.Key.create(name, key, auth)
+  end
+
+  defp render_keys([]) do
+    Shell.info("No keys have been created")
+  end
+
+  defp render_keys(keys) when is_list(keys) do
+    Shell.info("\nKeys:")
+
+    Enum.each(keys, fn params ->
+      Shell.info("------------")
+
+      render_key(params)
+      |> String.trim_trailing()
+      |> Shell.info()
+    end)
+
+    Shell.info("------------")
+    Shell.info("")
+  end
+
+  defp render_key(params) do
+    """
+      name:  #{params["name"]}
+      key:   #{params["key"]}
+    """
+  end
+end

--- a/lib/nerves_hub_cli.ex
+++ b/lib/nerves_hub_cli.ex
@@ -1,5 +1,14 @@
 defmodule NervesHubCLI do
   def home_dir do
-    System.get_env("NERVES_HUB_HOME") || Path.expand("~/.nerves_hub")
+    Application.get_env(:nerves_hub_cli, :home_dir) || System.get_env("NERVES_HUB_HOME") ||
+      Path.expand("~/.nerves_hub")
+  end
+
+  def public_keys(keys) when is_list(keys) do
+    keys = Enum.map(keys, &to_string/1)
+
+    NervesHubCLI.Key.local_keys()
+    |> Enum.filter(fn %{name: name} -> name in keys end)
+    |> Enum.map(&Map.get(&1, :key))
   end
 end

--- a/lib/nerves_hub_cli/api/key.ex
+++ b/lib/nerves_hub_cli/api/key.ex
@@ -1,0 +1,16 @@
+defmodule NervesHubCLI.API.Key do
+  alias NervesHubCLI.API
+
+  def list(auth) do
+    API.request(:get, "keys", "", auth)
+  end
+
+  def create(name, key, auth) do
+    params = %{name: name, key: key}
+    API.request(:post, "keys", params, auth)
+  end
+
+  def delete(name, auth) do
+    API.request(:delete, "keys/#{name}", "", auth)
+  end
+end

--- a/lib/nerves_hub_cli/application.ex
+++ b/lib/nerves_hub_cli/application.ex
@@ -7,6 +7,8 @@ defmodule NervesHubCLI.Application do
 
   def start(_type, _args) do
     NervesHubCLI.API.start_pool()
+    NervesHubCLI.User.init()
+    NervesHubCLI.Key.init()
     # List all child processes to be supervised
     children = [
       # Starts a worker by calling: NervesHubCLI.Worker.start_link(arg)

--- a/lib/nerves_hub_cli/key.ex
+++ b/lib/nerves_hub_cli/key.ex
@@ -1,0 +1,102 @@
+defmodule NervesHubCLI.Key do
+  alias NervesHubCLI.Crypto
+
+  @gen_file "fwup-key"
+
+  @public_ext ".pub"
+  @private_ext ".priv"
+
+  def init() do
+    data_dir()
+    |> File.mkdir_p()
+  end
+
+  def create(key_name, key_password) do
+    path = data_dir()
+
+    tmp_dir = Path.join(path, "tmp")
+    File.mkdir_p(tmp_dir)
+
+    default_private_key_file = Path.join(tmp_dir, @gen_file <> @private_ext)
+    default_public_key_file = Path.join(tmp_dir, @gen_file <> @public_ext)
+    final_private_key = Path.join(path, key_name <> @private_ext)
+    final_public_key = Path.join(path, key_name <> @public_ext)
+
+    with :ok <- fwup(["-g"], tmp_dir),
+         {:ok, key} <- File.read(default_private_key_file),
+         encrypted_key <- Crypto.encrypt(key, key_password),
+         :ok <- File.write(default_private_key_file, encrypted_key),
+         :ok <- File.cp(default_private_key_file, final_private_key),
+         :ok <- File.cp(default_public_key_file, final_public_key) do
+      File.rm_rf(tmp_dir)
+      {:ok, final_public_key, final_private_key}
+    else
+      error ->
+        File.rm_rf(tmp_dir)
+        error
+    end
+  end
+
+  def delete(name) do
+    path = data_dir()
+    File.rm(Path.join(path, name <> @private_ext))
+    File.rm(Path.join(path, name <> @public_ext))
+  end
+
+  def local_keys do
+    path = data_dir()
+
+    private_keys =
+      path
+      |> Path.join("*" <> @private_ext)
+      |> Path.wildcard()
+
+    private_key_names =
+      private_keys
+      |> Enum.map(&Path.basename(&1, private_ext()))
+      |> MapSet.new()
+
+    public_keys =
+      path
+      |> Path.join("*" <> @public_ext)
+      |> Path.wildcard()
+
+    public_key_names =
+      public_keys
+      |> Enum.map(&Path.basename(&1, public_ext()))
+      |> MapSet.new()
+
+    keypairs =
+      MapSet.intersection(public_key_names, private_key_names)
+      |> MapSet.to_list()
+
+    Enum.map(keypairs, fn name ->
+      {:ok, key} =
+        Path.join(path, name <> @public_ext)
+        |> File.read()
+
+      %{name: name, key: key}
+    end)
+  end
+
+  def exists?(name) do
+    local_keys()
+    |> Enum.any?(&(Map.get(&1, :name) == name))
+  end
+
+  def private_ext(), do: @private_ext
+  def public_ext(), do: @public_ext
+
+  defp fwup(args, path) do
+    path = path || File.cwd!()
+
+    case System.cmd("fwup", args, stderr_to_stdout: true, cd: path) do
+      {_output, 0} -> :ok
+      {error, _} -> {:error, error}
+    end
+  end
+
+  defp data_dir() do
+    Path.join([NervesHubCLI.home_dir(), "keys"])
+  end
+end

--- a/lib/nerves_hub_cli/user.ex
+++ b/lib/nerves_hub_cli/user.ex
@@ -5,6 +5,11 @@ defmodule NervesHubCLI.User do
   @csr "csr.pem"
   @cert "cert.pem"
 
+  def init() do
+    data_dir()
+    |> File.mkdir_p()
+  end
+
   def generate_csr(username, certificate_password) do
     # Create the data dir
     cert_files =


### PR DESCRIPTION
Add the following mix tasks:

* `nerves_hub.key list` -list all keys in the org
* `nerves_hub.key create [name]` - create a new key with the specified name
* `nerves_hub.key delete [name]` - delete the key with the specified name

All the key operations can take the boolean flag `--local` to only apply the operation to the local computer. 