### PR TITLE
Add mix command to make it easier to provision a device.

### DIFF
--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -1,6 +1,6 @@
 defmodule Mix.NervesHubCLI.Utils do
   def default_product do
-    config()[:app]
+    (config()[:name] || config()[:app])
   end
 
   def default_firmware do

--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -1,6 +1,6 @@
 defmodule Mix.NervesHubCLI.Utils do
   def default_product do
-    (config()[:name] || config()[:app])
+    config()[:name] || config()[:app]
   end
 
   def default_firmware do

--- a/lib/mix/tasks/nerves_hub.deployment.ex
+++ b/lib/mix/tasks/nerves_hub.deployment.ex
@@ -72,8 +72,9 @@ defmodule Mix.Tasks.NervesHub.Deployment do
 
   def list(opts) do
     product = opts[:product] || default_product()
-    
+
     auth = Shell.request_auth()
+
     case API.Deployment.list(product, auth) do
       {:ok, %{"data" => []}} ->
         Shell.info("No deployments have been created for product: #{product}")

--- a/lib/mix/tasks/nerves_hub.deployment.ex
+++ b/lib/mix/tasks/nerves_hub.deployment.ex
@@ -71,9 +71,9 @@ defmodule Mix.Tasks.NervesHub.Deployment do
   end
 
   def list(opts) do
-    auth = Shell.request_auth()
     product = opts[:product] || default_product()
-
+    
+    auth = Shell.request_auth()
     case API.Deployment.list(product, auth) do
       {:ok, %{"data" => []}} ->
         Shell.info("No deployments have been created for product: #{product}")


### PR DESCRIPTION
This PR adds the mix command
`nerves_hub.device provision [identifier]`

If called with no command line options, it will attempt to create a new certificate for the device, register it with the server, configure the environment, and call `mix firmware.burn`.

You can specify a location where you wish to place the temporary certificate files by passing `--path`. If a certificate for the device already exists at that path, you will be asked if you wish to use them or create new ones. You can also pass `--key` and `--cert` to specify which key and cert files to use. 