### PR TITLE
Add CLI for managing products

### DIFF
--- a/lib/mix/tasks/nerves_hub.product.ex
+++ b/lib/mix/tasks/nerves_hub.product.ex
@@ -1,0 +1,168 @@
+defmodule Mix.Tasks.NervesHub.Product do
+  use Mix.Task
+
+  import Mix.NervesHubCLI.Utils
+  alias NervesHubCLI.API
+  alias Mix.NervesHubCLI.Shell
+
+  @shortdoc "Manages your firmware signing keys"
+
+  @moduledoc """
+  Manages your products.
+
+  ## create
+
+  Create a new NervesHub product. The shell will prompt for information about the
+  product. This information can be passed by specifing one or all of the command
+  line options.
+
+    mix nerves_hub.product create
+
+  ### Command line options
+
+    * `--name` - (Optional) The product name.
+
+  ## list
+
+    mix nerves_hub.product list
+
+  ## delete
+
+  Call `list` to retreive product names
+
+    mix nerves_hub.firmware delete [product_name]
+
+  ## update
+
+  Update values on a product.
+  Call `list` to retreive product names
+
+  ### Examples
+
+  Change product name
+
+    mix nerves_hub.product update example name example_new
+  """
+
+  @switches [
+    name: :string
+  ]
+
+  def run(args) do
+    Application.ensure_all_started(:nerves_hub_cli)
+
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    org = org(opts)
+
+    case args do
+      ["list"] ->
+        list(org)
+
+      ["create"] ->
+        create(org, opts)
+
+      ["delete", product_name] ->
+        delete(org, product_name)
+
+      ["update", product, key, value] ->
+        update(org, product, key, value)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.product`.
+
+    Usage:
+      mix nerves_hub.product list
+      mix nerves_hub.product create
+      mix nerves_hub.product delete PRODUCT_NAME
+      mix nerves_hub.product update PRODUCT_NAME KEY VALUE
+
+    Run `mix help nerves_hub.product` for more information.
+    """)
+  end
+
+  def list(org) do
+    auth = Shell.request_auth()
+
+    case API.Product.list(org, auth) do
+      {:ok, %{"data" => []}} ->
+        Shell.info("No products has been created")
+
+      {:ok, %{"data" => products}} ->
+        Shell.info("")
+        Shell.info("Products:")
+
+        Enum.each(products, fn params ->
+          Shell.info("------------")
+
+          render_product(params)
+          |> String.trim_trailing()
+          |> Shell.info()
+        end)
+
+        Shell.info("")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def create(org, opts) do
+    name = opts[:name] || Shell.prompt("name:")
+
+    auth = Shell.request_auth()
+
+    case API.Product.create(org, name, auth) do
+      {:ok, %{"data" => %{} = _product}} ->
+        Shell.info("Product #{name} created")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def delete(org, product_name) do
+    if Mix.shell().yes?("Delete product #{product_name}?") do
+      auth = Shell.request_auth()
+
+      case API.Product.delete(org, product_name, auth) do
+        {:ok, ""} ->
+          Shell.info("Product deleted successfully")
+
+        error ->
+          Shell.render_error(error)
+      end
+    end
+  end
+
+  def update(org, product, key, value) do
+    auth = Shell.request_auth()
+
+    case API.Product.update(org, product, Map.put(%{}, key, value), auth) do
+      {:ok, %{"data" => product}} ->
+        Shell.info("")
+        Shell.info("Product Updated:")
+
+        render_product(product)
+        |> String.trim_trailing()
+        |> Shell.info()
+
+        Shell.info("")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  defp render_product(params) do
+    """
+      name: #{params["name"]}
+    """
+  end
+end

--- a/lib/nerves_hub_cli/api/product.ex
+++ b/lib/nerves_hub_cli/api/product.ex
@@ -1,5 +1,5 @@
 defmodule NervesHubCLI.API.Product do
-  # alias NervesHubCLI.API
+  alias NervesHubCLI.API
   alias NervesHubCLI.API.Org
 
   @path "products"
@@ -12,5 +12,23 @@ defmodule NervesHubCLI.API.Product do
 
   def path(org, product) do
     Path.join([path(org), product])
+  end
+
+  def list(org, auth) do
+    API.request(:get, path(org), "", auth)
+  end
+
+  def create(org, product, auth) do
+    params = %{name: product}
+    API.request(:post, path(org), params, auth)
+  end
+
+  def delete(org, product, auth) do
+    API.request(:delete, path(org, product), "", auth)
+  end
+
+  def update(org, product, params, auth) do
+    params = %{product: params}
+    API.request(:put, path(org, product), params, auth)
   end
 end


### PR DESCRIPTION
This PR allows the management of products from the command line.
It adds the following mix tasks

* `nerves_hub.product list`
* `nerves_hub.product create`
* `nerves_hub.product delete PRODUCT_NAME`
* `nerves_hub.product update PRODUCT_NAME KEY VALUE`

Depends on https://github.com/nerves-hub/nerves_hub_web/pull/222