### PR TITLE
Fix loading params from env vars.

### DIFF
--- a/lib/mix/nerves_hub/shell.ex
+++ b/lib/mix/nerves_hub/shell.ex
@@ -1,4 +1,6 @@
 defmodule Mix.NervesHubCLI.Shell do
+  alias NervesHubCLI.Certificate
+
   def info(output) do
     Mix.shell().info(output)
   end
@@ -24,7 +26,7 @@ defmodule Mix.NervesHubCLI.Shell do
     env_key = System.get_env("NERVES_HUB_KEY")
 
     if env_cert != nil and env_key != nil do
-      %{cert: env_cert, key: env_key}
+      %{cert: Certificate.pem_to_der(env_cert), key: Certificate.pem_to_der(env_key)}
     else
       password = password_get(prompt)
 
@@ -43,7 +45,7 @@ defmodule Mix.NervesHubCLI.Shell do
     env_priv_key = System.get_env("NERVES_HUB_FW_PUBLIC_KEY")
 
     if env_pub_key != nil and env_priv_key != nil do
-      {:ok, env_pub_key, env_priv_key}
+      {:ok, env_priv_key, env_pub_key}
     else
       key_password = password_get(prompt)
       NervesHubCLI.Key.get(org, name, key_password)

--- a/lib/nerves_hub_cli.ex
+++ b/lib/nerves_hub_cli.ex
@@ -15,16 +15,20 @@ defmodule NervesHubCLI do
   def public_keys(keys) when is_list(keys) do
     org = Mix.NervesHubCLI.Utils.org([])
     local_keys = NervesHubCLI.Key.local_keys(org)
-    Enum.reduce(keys, [], &find_key(&1, &2, local_keys))
+
+    Enum.reduce(keys, [], fn {key_name_or_bin, acc} ->
+      maybe_key = find_key(key_name_or_bin, local_keys)
+      if maybe_key, do: [maybe_key | acc], else: acc
+    end)
   end
 
-  defp find_key(key, acc, _) when is_binary(key) do
-    [key | acc]
+  defp find_key(key, _local_keys) when is_binary(key) do
+    key
   end
 
-  defp find_key(key_name, acc, local_keys) when is_atom(key_name) do
-    Enum.find_value(local_keys, [], fn %{name: name, key: key} ->
+  defp find_key(key_name, local_keys) when is_atom(key_name) do
+    Enum.find_value(local_keys, fn %{name: name, key: key} ->
       to_string(key_name) == name && [key]
-    end) ++ acc
+    end)
   end
 end

--- a/lib/nerves_hub_cli.ex
+++ b/lib/nerves_hub_cli.ex
@@ -13,11 +13,18 @@ defmodule NervesHubCLI do
   def public_keys([]), do: []
 
   def public_keys(keys) when is_list(keys) do
-    keys = Enum.map(keys, &to_string/1)
     org = Mix.NervesHubCLI.Utils.org([])
+    local_keys = NervesHubCLI.Key.local_keys(org)
+    Enum.reduce(keys, [], &find_key(&1, &2, local_keys))
+  end
 
-    NervesHubCLI.Key.local_keys(org)
-    |> Enum.filter(fn %{name: name} -> name in keys end)
-    |> Enum.map(&Map.get(&1, :key))
+  defp find_key(key, acc, _) when is_binary(key) do
+    [key | acc]
+  end
+
+  defp find_key(key_name, acc, local_keys) when is_atom(key_name) do
+    Enum.find_value(local_keys, [], fn %{name: name, key: key} ->
+      to_string(key_name) == name && [key]
+    end) ++ acc
   end
 end


### PR DESCRIPTION
* `NERVES_HUB_FW_PRIVATE_KEY` and `NERVES_HUB_FW_PUBLIC_KEY` were
backwards.
* `NERVES_HUB_CERT` and `NERVES_HUB_KEY` needed to be converted to pem
* Allow loading `NERVES_HUB_FW_PUBLIC_KEY` into `NervesHub.public_keys()`