### PR TITLE
Add support for setting firmware ttl

### DIFF
--- a/lib/mix/tasks/nerves_hub.firmware.ex
+++ b/lib/mix/tasks/nerves_hub.firmware.ex
@@ -60,7 +60,8 @@ defmodule Mix.Tasks.NervesHub.Firmware do
   @switches [
     product: :string,
     deploy: :keep,
-    key: :string
+    key: :string,
+    ttl: :integer
   ]
 
   def run(args) do
@@ -175,9 +176,11 @@ defmodule Mix.Tasks.NervesHub.Firmware do
 
     auth = Shell.request_auth()
 
-    case API.Firmware.create(org, product, firmware, auth) do
+    ttl = opts[:ttl]
+
+    case API.Firmware.create(org, product, firmware, ttl, auth) do
       {:ok, %{"data" => %{} = firmware}} ->
-        Shell.info("Firmware published successfully")
+        Shell.info("\nFirmware published successfully")
 
         Keyword.get_values(opts, :deploy)
         |> maybe_deploy(firmware, org, product, auth)

--- a/lib/nerves_hub_cli/api/firmware.ex
+++ b/lib/nerves_hub_cli/api/firmware.ex
@@ -12,8 +12,9 @@ defmodule NervesHubCLI.API.Firmware do
     API.request(:get, path(org, product), "", auth)
   end
 
-  def create(org, product, tar, auth) do
-    API.file_request(:post, path(org, product), tar, auth)
+  def create(org, product, tar, ttl, auth) do
+    params = %{ttl: ttl}
+    API.file_request(:post, path(org, product), tar, params, auth)
   end
 
   def delete(org, product, uuid, auth) do


### PR DESCRIPTION
This PR adds support for setting the firmware `ttl` on firmware records. As a side effect, it also contains an added progress bar for firmware uploads.

Requires this PR https://github.com/nerves-hub/nerves_hub_web/pull/284
Fixes https://github.com/nerves-hub/nerves_hub_cli/issues/13