### PR TITLE
Use Tesla as HTTP Client

### DIFF
--- a/lib/mix/nerves_hub/shell.ex
+++ b/lib/mix/nerves_hub/shell.ex
@@ -83,6 +83,11 @@ defmodule Mix.NervesHubCLI.Shell do
     error(reason)
   end
 
+  def render_error({:error, %{"errors" => reasons}}) do
+    error("HTTP error")
+    for {key, reason} <- reasons, do: error("  #{key}: #{reason}")
+  end
+
   def render_error(error) do
     error("Unhandled error: #{inspect(error)}")
   end

--- a/lib/nerves_hub_cli/api.ex
+++ b/lib/nerves_hub_cli/api.ex
@@ -8,7 +8,6 @@ defmodule NervesHubCLI.API do
   use Tesla
   adapter(Tesla.Adapter.Hackney)
   if Mix.env() != :prod, do: plug(Tesla.Middleware.Logger)
-  plug(Tesla.Middleware.Headers, [{"Content-Type", "application/json"}])
   plug(Tesla.Middleware.FollowRedirects, max_redirects: 5)
   plug(Tesla.Middleware.JSON)
 
@@ -91,7 +90,7 @@ defmodule NervesHubCLI.API do
   @spec ssl_options(NervesHubCLI.User.auth_map() | %{}) :: Keyword.t()
   defp ssl_options(%{key: key, cert: cert}) do
     [
-      key: {:ECPrivateKey, PrivateKey.to_der(key)},
+      key: {:ECPrivateKey, X509.PrivateKey.to_der(key)},
       cert: X509.Certificate.to_der(cert),
       server_name_indication: to_charlist(@host)
     ]

--- a/lib/nerves_hub_cli/application.ex
+++ b/lib/nerves_hub_cli/application.ex
@@ -6,7 +6,6 @@ defmodule NervesHubCLI.Application do
   use Application
 
   def start(_type, _args) do
-    NervesHubCLI.API.start_pool()
     NervesHubCLI.User.init()
     # List all child processes to be supervised
     children = [

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule NervesHubCLI.MixProject do
   defp deps do
     [
       {:jason, "~> 1.0"},
+      {:tesla, "~> 1.1"},
       {:hackney, "~> 1.9"},
       {:pbcs, "~> 0.1"},
       {:x509, "~> 0.3"},

--- a/mix.lock
+++ b/mix.lock
@@ -9,11 +9,13 @@
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "pbcs": {:hex, :pbcs, "0.1.0", "6f79ce81d93edf5ac41fcd8b32fb203ad6895ebdb33d115e14a5bd955b90020a", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
+  "tesla": {:hex, :tesla, "1.1.0", "666e90b65d5c1edd4cd9ba96a24cf5d552cc29ccf5b22ca0cc86c465f732ba40", [:mix], [{:exjsx, ">= 3.0.0", [hex: :exjsx, repo: "hexpm", optional: true]}, {:fuse, "~> 2.4", [hex: :fuse, repo: "hexpm", optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4.0", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:jason, ">= 1.0.0", [hex: :jason, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:poison, ">= 1.0.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
   "x509": {:hex, :x509, "0.3.0", "c6f3db66960c6e4f424d1e6cca5c7d730e0a577af8dc115a613f4560ce1df6d3", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
I prefer Tesla as an HTTP Client because it should hopefully allow us to easily write some tests based on fixtures. This still uses the `hackney` adapter to do the clientside ssl stuff, just wrapped in an abstraction.

