### PR TITLE
Replace calls to openssl with the x509 package

### DIFF
--- a/lib/mix/nerves_hub/shell.ex
+++ b/lib/mix/nerves_hub/shell.ex
@@ -35,7 +35,7 @@ defmodule Mix.NervesHubCLI.Shell do
         {:ok, auth} ->
           auth
 
-        :error ->
+        {:error, _} ->
           __MODULE__.raise("Invalid password")
       end
     end

--- a/lib/nerves_hub_cli/certificate.ex
+++ b/lib/nerves_hub_cli/certificate.ex
@@ -1,20 +1,4 @@
 defmodule NervesHubCLI.Certificate do
-  @spec generate_key(String.t()) :: :ok | {:error, binary()}
-  def generate_key(key_file) do
-    path = Path.dirname(key_file)
-
-    ["ecparam", "-genkey", "-name", "prime256v1", "-noout", "-out", key_file]
-    |> openssl(path)
-  end
-
-  @spec generate_csr(String.t(), String.t(), String.t()) :: :ok | {:error, binary()}
-  def generate_csr(org, key_file, csr_file) do
-    path = Path.dirname(csr_file)
-
-    ["req", "-new", "-sha256", "-key", key_file, "-out", csr_file, "-subj", "/O=#{org}"]
-    |> openssl(path)
-  end
-
   def pem_to_der(<<"-----BEGIN", _rest::binary>> = cert) do
     [{_, cert, _}] = :public_key.pem_decode(cert)
     cert
@@ -24,14 +8,5 @@ defmodule NervesHubCLI.Certificate do
   def default_description() do
     {:ok, hostname} = :inet.gethostname()
     to_string(hostname)
-  end
-
-  defp openssl(args, path) do
-    path = path || File.cwd!()
-
-    case System.cmd("openssl", args, stderr_to_stdout: true, cd: path) do
-      {_output, 0} -> :ok
-      {error, _} -> {:error, error}
-    end
   end
 end

--- a/lib/nerves_hub_cli/crypto.ex
+++ b/lib/nerves_hub_cli/crypto.ex
@@ -1,4 +1,5 @@
 defmodule NervesHubCLI.Crypto do
+  @spec encrypt(String.t(), String.t(), String.t()) :: binary() | {:error, String.t()}
   def encrypt(plain_text, password, tag \\ "") do
     protected = %{
       alg: "PBES2-HS512",
@@ -10,7 +11,12 @@ defmodule NervesHubCLI.Crypto do
     PBCS.encrypt({tag, plain_text}, protected, password: password)
   end
 
+  @spec decrypt(binary(), any(), binary()) :: {:ok, binary()} | {:error, String.t()}
   def decrypt(cipher_text, password, tag \\ "") do
-    PBCS.decrypt({tag, cipher_text}, password: password)
+    case PBCS.decrypt({tag, cipher_text}, password: password) do
+      plain_text when is_binary(plain_text) -> {:ok, plain_text}
+      :error -> {:error, "unknown"}
+      other -> other
+    end
   end
 end

--- a/lib/nerves_hub_cli/device.ex
+++ b/lib/nerves_hub_cli/device.ex
@@ -1,16 +1,2 @@
 defmodule NervesHubCLI.Device do
-  alias NervesHubCLI.Certificate
-
-  def generate_csr(identifier, path) do
-    key_path = Path.join(path, "#{identifier}-key.pem")
-    csr_path = Path.join(path, "#{identifier}-csr.pem")
-
-    with :ok <- Certificate.generate_key(key_path),
-         :ok <- Certificate.generate_csr(identifier, key_path, csr_path) do
-      File.read(csr_path)
-    else
-      error ->
-        error
-    end
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule NervesHubCLI.MixProject do
       {:jason, "~> 1.0"},
       {:hackney, "~> 1.9"},
       {:pbcs, "~> 0.1"},
+      {:x509, "~> 0.3"},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -15,4 +15,5 @@
   "pbcs": {:hex, :pbcs, "0.1.0", "6f79ce81d93edf5ac41fcd8b32fb203ad6895ebdb33d115e14a5bd955b90020a", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+  "x509": {:hex, :x509, "0.3.0", "c6f3db66960c6e4f424d1e6cca5c7d730e0a577af8dc115a613f4560ce1df6d3", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
The `x509` package wraps and extends Erlang's built-in certificate management routines. While not perfect, it removes a runtime dependency on openssl's CLI and it slightly easier to understand and use. 
