### PR TITLE
Add mix commands for managing ca certificates

### DIFF
--- a/lib/mix/tasks/nerves_hub.ca_certificate.ex
+++ b/lib/mix/tasks/nerves_hub.ca_certificate.ex
@@ -1,0 +1,133 @@
+defmodule Mix.Tasks.NervesHub.CaCertificate do
+  use Mix.Task
+
+  import Mix.NervesHubCLI.Utils
+  alias NervesHubCLI.API
+  alias Mix.NervesHubCLI.Shell
+
+  @shortdoc "Manages CA certificates"
+
+  @moduledoc """
+  Manages CA certificates
+
+  ## list
+
+  mix nerves_hub.ca_certificate list
+
+  ## create
+
+  mix nerves_hub.ca_certificate create CERT_PATH
+
+  ## delete
+
+  mix nerves_hub.ca_certificate delete CERT_SERIAL
+  """
+
+  @switches [
+    org: :string
+  ]
+
+  def run(args) do
+    Application.ensure_all_started(:nerves_hub_cli)
+
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    org = org(opts)
+
+    case args do
+      ["list"] ->
+        list(org)
+
+      ["create", certificate_path] ->
+        create(certificate_path, org)
+
+      ["delete", serial] ->
+        delete(serial, org)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.ca_certificate`.
+
+    Usage:
+      mix nerves_hub.ca_certificate list
+      mix nerves_hub.ca_certificate create CERT_PATH
+      mix nerves_hub.ca_certificate delete CERT_SERIAL
+
+    Run `mix help nerves_hub.ca_certificate` for more information.
+    """)
+  end
+
+  def list(org) do
+    auth = Shell.request_auth()
+
+    case API.CACertificate.list(org, auth) do
+      {:ok, %{"data" => ca_certificates}} ->
+        render_ca_certificates(ca_certificates)
+
+      error ->
+        Shell.info("Failed to list CA certificates \nreason: #{inspect(error)}")
+    end
+  end
+
+  def create(cert_path, org) do
+    with {:ok, cert_pem} <- File.read(cert_path),
+         auth = Shell.request_auth(),
+         {:ok, %{"data" => %{"serial" => serial}}} <-
+           API.CACertificate.create(org, cert_pem, auth) do
+      Shell.info("CA certificate '#{serial}' created.")
+    else
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def delete(serial, org) do
+    if Shell.yes?("Delete CA certificate '#{serial}'?") do
+      auth = Shell.request_auth()
+      Shell.info("Deleting CA certificate '#{serial}'")
+
+      case API.CACertificate.delete(org, serial, auth) do
+        {:ok, ""} ->
+          Shell.info("CA certificate deleted successfully")
+
+        error ->
+          Shell.render_error(error)
+      end
+    end
+  end
+
+  defp render_ca_certificates([]) do
+    Shell.info("No CA certificates have been created.")
+  end
+
+  defp render_ca_certificates(ca_certificates) when is_list(ca_certificates) do
+    Shell.info("\nCA Certificates:")
+
+    Enum.each(ca_certificates, fn params ->
+      Shell.info("------------")
+
+      render_ca_certificate(params)
+      |> String.trim_trailing()
+      |> Shell.info()
+    end)
+
+    Shell.info("------------")
+    Shell.info("")
+  end
+
+  defp render_ca_certificate(params) do
+    {:ok, not_before, _} = DateTime.from_iso8601(params["not_before"])
+    {:ok, not_after, _} = DateTime.from_iso8601(params["not_after"])
+
+    """
+      serial:     #{params["serial"]}
+      validity:   #{DateTime.to_date(not_before)} - #{DateTime.to_date(not_after)} UTC
+    """
+  end
+end

--- a/lib/nerves_hub_cli/api/ca_certificate.ex
+++ b/lib/nerves_hub_cli/api/ca_certificate.ex
@@ -1,0 +1,27 @@
+defmodule NervesHubCLI.API.CACertificate do
+  alias NervesHubCLI.API
+  alias NervesHubCLI.API.Org
+
+  @path "ca_certificates"
+
+  def path(org) do
+    Path.join([Org.path(org), @path])
+  end
+
+  def path(org, serial) do
+    Path.join([path(org), serial])
+  end
+
+  def list(org, auth) do
+    API.request(:get, path(org), "", auth)
+  end
+
+  def create(org, cert_pem, auth) do
+    params = %{cert: Base.encode64(cert_pem)}
+    API.request(:post, path(org), params, auth)
+  end
+
+  def delete(org, serial, auth) do
+    API.request(:delete, path(org, serial), "", auth)
+  end
+end


### PR DESCRIPTION
Adds the following mix commands

* `nerves_hub.ca_certificate list` - list all ca certificates.
* `nerves_hub.ca_certificate create CERT_PATH` - create a new ca_certificate record from the supplied pem certificate path.
* `nerves_hub.ca_certificate delete CERT_SERIAL` - delete the ca certificate with the supplied serial.

depends on https://github.com/nerves-hub/nerves_hub_web/pull/304