### PR TITLE
Revert "Extract product before trying product in meta"

### DIFF
--- a/lib/mix/tasks/nerves_hub.firmware.ex
+++ b/lib/mix/tasks/nerves_hub.firmware.ex
@@ -151,7 +151,7 @@ defmodule Mix.Tasks.NervesHub.Firmware do
       |> Shell.info()
 
       if Shell.yes?("Publish Firmware?") do
-        product = product(opts) || metadata["product"]
+        product = metadata["product"]
         publish(firmware, org, product, opts)
       end
     else


### PR DESCRIPTION
I clicked the wrong buttons. I think we should revert this. The server derives everything it knows from the firmware metadata so I don't think this method will work.
Reverts nerves-hub/nerves_hub_cli#65