### PR TITLE
Move nerves_hub config from mix project to config.exs

### DIFF
--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -14,8 +14,7 @@ defmodule Mix.NervesHubCLI.Utils do
     # not found
     org =
       Keyword.get(opts, :org) || System.get_env("NERVES_HUB_ORG") ||
-        Keyword.get(config(), :nerves_hub, [])
-        |> Keyword.get(:org) || Config.get(:org) ||
+        Application.get_env(:nerves_hub, :org) || Config.get(:org) ||
         Shell.raise("""
         Cound not determine organization
         Organization is set in the following order
@@ -28,13 +27,10 @@ defmodule Mix.NervesHubCLI.Utils do
 
             export NERVES_HUB_ORG=org_name
 
-          By setting it in the project's mix config
+          By setting it in the project's config.exs
 
-            def project do
-              [
-                nerves_hub: [org: org_name]
-              ]
-            end
+            config :nerves_hub,
+              org: "org_name"
 
           Your user org from the NervesHub config
 


### PR DESCRIPTION
Configuring `nerves_hub` from the mix.exs file prevents the configuration from being accessible when compiling dependencies. Moving this to the application config not only fixes the scoping issue, but has the added benefit of organizing all the config in one place.