### PR TITLE
Update documentation

### DIFF
--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -122,7 +122,7 @@ defmodule Mix.Tasks.NervesHub.Device do
       mix nerves_hub.device cert list DEVICE_IDENTIFIER
       mix nerves_hub.device cert create DEVICE_IDENTIFIER
 
-    Run `mix help nerves_hub.deployment` for more information.
+    Run `mix help nerves_hub.device` for more information.
     """)
   end
 

--- a/lib/mix/tasks/nerves_hub.firmware.ex
+++ b/lib/mix/tasks/nerves_hub.firmware.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.NervesHub.Firmware do
       firmware publish. This key can be passed multiple times to update
       multiple deployments.
     * `--key` - (Optional) The firmware signing key to sign the firmware with.
+    * `--ttl` - (Optional) The firmware max time to live seconds.
 
   ## list
 
@@ -111,6 +112,8 @@ defmodule Mix.Tasks.NervesHub.Firmware do
       mix nerves_hub.firmware publish
       mix nerves_hub.firmware delete
       mix nerves_hub.firmware sign
+
+    Run `mix help nerves_hub.firmware` for more information.
     """)
   end
 


### PR DESCRIPTION
* Document `--ttl` option to `nerves_hub.firmware publish`
* Ensure task help messages are correct and consistent