### PR TITLE
Use Shell password_get instead of Hex

### DIFF
--- a/lib/mix/tasks/nerves_hub.user.ex
+++ b/lib/mix/tasks/nerves_hub.user.ex
@@ -114,8 +114,8 @@ defmodule Mix.Tasks.NervesHub.User do
   def register() do
     email = Shell.prompt("Email address:") |> String.trim()
     username = Shell.prompt("Username:") |> String.trim()
-    password = Mix.Tasks.Hex.password_get("NervesHub password:") |> String.trim()
-    confirm = Mix.Tasks.Hex.password_get("NervesHub password (confirm):") |> String.trim()
+    password = Shell.password_get("NervesHub password:") |> String.trim()
+    confirm = Shell.password_get("NervesHub password (confirm):") |> String.trim()
 
     unless String.equivalent?(password, confirm) do
       Mix.raise("Entered passwords do not match")
@@ -128,7 +128,7 @@ defmodule Mix.Tasks.NervesHub.User do
 
   def auth() do
     email = Shell.prompt("Email address:") |> String.trim()
-    password = Mix.Tasks.Hex.password_get("NervesHub password:") |> String.trim()
+    password = Shell.password_get("NervesHub password:") |> String.trim()
     Shell.info("Authenticating...")
 
     case NervesHubCore.User.auth(email, password) do


### PR DESCRIPTION
This should call the password_get functions we have in Shell instead of trying to call out to hex.

Fixes an issue where calling `mix nerves_hub.user auth` results in an error when requesting the password.

```
** (exit) exited in: GenServer.call(Hex.State, {:get, {Map, :fetch, [:clean_pass]}}, 5000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir) lib/gen_server.ex:958: GenServer.call/3
    lib/hex/state.ex:82: Hex.State.fetch!/1
    lib/mix/tasks/hex.ex:310: Mix.Tasks.Hex.password_get/1
    (nerves_hub_cli) lib/mix/tasks/nerves_hub.user.ex:131: Mix.Tasks.NervesHub.User.auth/0
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```