### PR TITLE
Fix typos and expand org abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * Enhancements
   * Added mix tasks
-    * `mix nerves_hub.ca_certificate list` - List all ca certificates for an org.
+    * `mix nerves_hub.ca_certificate list` - List all CA certificates for an org.
     * `mix nerves_hub.ca_certificate create CERT_PATH` - Add a CA certificate.
     * `mix nerves_hub.ca_certificate delete CERT_SERIAL`- Delete a CA certificate.
   * The API modules have been moved to `nerves_hub_core` for runtime reusability.
@@ -30,7 +30,7 @@
   * Updated mix tasks
     * `mix nerves_hub.product create` - Will take the product name from the
       Mix project config by default.
-    * `mix enrves_hub.device burn` - Will now call `mix burn` instead of
+    * `mix nerves_hub.device burn` - Will now call `mix burn` instead of
       `mix firmware.burn`.
   * Certificate functions are performed in Erlang and no longer call out to
     openssl.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Hex version](https://img.shields.io/hexpm/v/nerves_hub_cli.svg "Hex version")](https://hex.pm/packages/nerves_hub_cli)
 
 `NervesHubCLI` provides a set of [Mix](https://hexdocs.pm/mix/Mix.html) tasks so
-that you can work with [NervesHub](https://www.nerves-hub.org) from the command
-line. Features include:
+that you can work with [NervesHub](https://www.nerves-hub.org) from the
+command-line. Features include:
 
 * Uploading firmware to NervesHub
 * Generating device certificates and registration
@@ -20,7 +20,7 @@ The recommended way of using the CLI is to include
 components necessary to use it.
 
 Once installed, you can access available commands and documentation from the
-commandline using `mix help`:
+command-line using `mix help`:
 
 ```sh
 $ mix help

--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -20,7 +20,7 @@ defmodule Mix.NervesHubCLI.Utils do
         Organization is set in the following order
 
           From the command line
-          
+
             --org org_name
 
           By setting the environment variable NERVES_HUB_ORG
@@ -37,7 +37,7 @@ defmodule Mix.NervesHubCLI.Utils do
             NervesHubCLI.Config.get(:org)
         """)
 
-    Shell.info("NervesHub org: #{org}")
+    Shell.info("NervesHub organization: #{org}")
     org
   end
 

--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -7,7 +7,7 @@ defmodule Mix.NervesHubCLI.Utils do
   end
 
   def org(opts) do
-    # command line options
+    # command-line options
     # environment
     # project
     # user

--- a/lib/mix/tasks/nerves_hub.deployment.ex
+++ b/lib/mix/tasks/nerves_hub.deployment.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.NervesHub.Deployment do
 
     mix nerves_hub.deployment list
 
-  ### Command line options
+  ### Command-line options
 
     * `--product` - (Optional) Only show deployments for one product.
       This defaults to the Mix Project config `:app` name.
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.NervesHub.Deployment do
 
     mix nerves_hub.deployment create
 
-  ### Command line options
+  ### Command-line options
 
     * `--name` - (Optional) The deployment name
     * `--firmware` - (Optional) The firmware UUID

--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.NervesHub.Device do
 
     mix nerves_hub.device create
 
-  ### Command line options
+  ### Command-line options
 
     * `--identifier` - (Optional) The device identifier
     * `--description` - (Optional) The description of the device
@@ -43,13 +43,13 @@ defmodule Mix.Tasks.NervesHub.Device do
 
   Combine a firmware image with NervesHub provisioning information and burn the
   result to an attached MicroSD card or file. This requires that the device
-  was already created. Calling burn without passing command line options will
+  was already created. Calling burn without passing command-line options will
   generate a new cert pair for the device. The command will end with calling
   mix firmware.burn.
 
     mix nerves_hub.device burn DEVICE_IDENTIFIER
 
-  ### Command line options
+  ### Command-line options
 
     * `--cert` - (Optional) A path to an existing device certificate
     * `--key` - (Optional) A path to an existing device private key
@@ -68,7 +68,7 @@ defmodule Mix.Tasks.NervesHub.Device do
 
     mix nerves_hub.device cert create DEVICE_IDENTIFIER
 
-  ### Command line options
+  ### Command-line options
 
     * `--path` - (Optional) A local location for storing certificates
 

--- a/lib/mix/tasks/nerves_hub.firmware.ex
+++ b/lib/mix/tasks/nerves_hub.firmware.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.NervesHub.Firmware do
 
     mix nerves_hub.firmware publish [Optional: /path/to/app.firmware]
 
-  ### Command line options
+  ### Command-line options
 
     * `--product` - (Optional) The product name to publish the firmware to.
       This defaults to the Mix Project config `:app` name.
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.NervesHub.Firmware do
 
     mix nerves_hub.firmware list
 
-  ### Command line options
+  ### Command-line options
 
     * `--product` - (Optional) The product name to publish the firmware to.
       This defaults to the Mix Project config `:app` name.
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.NervesHub.Firmware do
 
     mix nerves_hub.firmware sign [Optional: /path/to/app.firmware]
 
-  ### Command line options
+  ### Command-line options
 
     * `--key` - (Optional) The firmware signing key to sign the firmware with.
 

--- a/lib/mix/tasks/nerves_hub.key.ex
+++ b/lib/mix/tasks/nerves_hub.key.ex
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.NervesHub.Key do
 
     mix nerves_hub.key list
 
-  ### Command line options
+  ### Command-line options
 
     * `--local` - (Optional) Do not request key information from NervesHub
 
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.NervesHub.Key do
 
     mix nerves_hub.key create NAME
 
-  ### Command line options
+  ### Command-line options
 
     * `--local` - (Optional) Do not register the public key with NervesHub
 
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.NervesHub.Key do
 
     mix nerves_hub.key delete NAME
 
-  ### Command line options
+  ### Command-line options
 
     * `--local` - (Optional) Perform the operation only locally defaults to
       `false` which will perform both local and remote operations
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.NervesHub.Key do
 
     mix nerves_hub.key import NAME PUBLIC_KEY_FILE PRIVATE_KEY_FILE
 
-  ### Command line options
+  ### Command-line options
 
     * `--local` - (Optional) Do not register the public key with NervesHub
 
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.NervesHub.Key do
 
     mix nerves_hub.key export NAME
 
-  ### Command line options
+  ### Command-line options
 
     * `--path` - (Optional) A local location for exporting keys.
   """

--- a/lib/mix/tasks/nerves_hub.product.ex
+++ b/lib/mix/tasks/nerves_hub.product.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.NervesHub.Product do
 
     mix nerves_hub.product create
 
-  ### Command line options
+  ### Command-line options
 
     * `--name` - (Optional) The product name
 

--- a/lib/mix/tasks/nerves_hub.user.ex
+++ b/lib/mix/tasks/nerves_hub.user.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.NervesHub.User do
 
     mix nerves_hub.user cert export
 
-  ### Command line options
+  ### Command-line options
 
     * `--path` - (Optional) A local location for exporting certificate.
   """

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule NervesHubCLI.MixProject do
   end
 
   defp description do
-    "NervesHub Mix command line interface "
+    "NervesHub Mix command-line interface "
   end
 
   defp package do


### PR DESCRIPTION
Apparently, the proper spelling is command-line. That spelling is also consistent with Elixir, so update our versions. Also expand org to organization where the user will see it.