### PR TITLE
Show the API endpoint when running commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ automation. The following variables are available:
 * `NERVES_HUB_FW_PRIVATE_KEY` - Fwup signing private key
 * `NERVES_HUB_FW_PUBLIC_KEY`  - Fwup signing public key
 * `NERVES_HUB_HOME` - NervesHub CLI data directory (defaults to `~/.nerves-hub`)
-* `NERVES_HUB_HOST` - NervesHub server IP address or hostname
-* `NERVES_HUB_PORT` - Port for NervesHub
+* `NERVES_HUB_HOST` - NervesHub API endpoint IP address or hostname (defaults to `api.nerves-hub.org`)
+* `NERVES_HUB_PORT` - NervesHub API endpoint port (defaults to 443)
 * `NERVES_HUB_NON_INTERACTIVE` - Force all yes/no user interaction to be yes
 
 For more information on using the CLI, see the

--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -6,6 +6,17 @@ defmodule Mix.NervesHubCLI.Utils do
     Keyword.get(opts, :product) || config()[:name] || config()[:app]
   end
 
+  @doc """
+  Print the API endpoint that's being used to communicate with the NervesHub server
+  """
+  @spec show_api_endpoint() :: String.t()
+  def show_api_endpoint() do
+    endpoint = NervesHubCore.API.endpoint()
+    uri = URI.parse(endpoint)
+
+    Shell.info("NervesHub server: #{uri.host}:#{uri.port}")
+  end
+
   def org(opts) do
     # command line options
     # environment

--- a/lib/mix/tasks/nerves_hub.ca_certificate.ex
+++ b/lib/mix/tasks/nerves_hub.ca_certificate.ex
@@ -31,6 +31,7 @@ defmodule Mix.Tasks.NervesHub.CaCertificate do
 
     {opts, args} = OptionParser.parse!(args, strict: @switches)
 
+    show_api_endpoint()
     org = org(opts)
 
     case args do

--- a/lib/mix/tasks/nerves_hub.deployment.ex
+++ b/lib/mix/tasks/nerves_hub.deployment.ex
@@ -68,6 +68,7 @@ defmodule Mix.Tasks.NervesHub.Deployment do
 
     {opts, args} = OptionParser.parse!(args, strict: @switches)
 
+    show_api_endpoint()
     org = org(opts)
     product = product(opts)
 

--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -91,6 +91,7 @@ defmodule Mix.Tasks.NervesHub.Device do
 
     {opts, args} = OptionParser.parse!(args, strict: @switches)
 
+    show_api_endpoint()
     org = org(opts)
 
     case args do

--- a/lib/mix/tasks/nerves_hub.firmware.ex
+++ b/lib/mix/tasks/nerves_hub.firmware.ex
@@ -71,8 +71,9 @@ defmodule Mix.Tasks.NervesHub.Firmware do
 
     {opts, args} = OptionParser.parse!(args, strict: @switches)
 
-    product = product(opts)
+    show_api_endpoint()
     org = org(opts)
+    product = product(opts)
 
     case args do
       ["list"] ->

--- a/lib/mix/tasks/nerves_hub.key.ex
+++ b/lib/mix/tasks/nerves_hub.key.ex
@@ -96,6 +96,7 @@ defmodule Mix.Tasks.NervesHub.Key do
 
     {opts, args} = OptionParser.parse!(args, strict: @switches)
 
+    show_api_endpoint()
     org = org(opts)
 
     case args do

--- a/lib/mix/tasks/nerves_hub.product.ex
+++ b/lib/mix/tasks/nerves_hub.product.ex
@@ -54,6 +54,7 @@ defmodule Mix.Tasks.NervesHub.Product do
 
     {opts, args} = OptionParser.parse!(args, strict: @switches)
 
+    show_api_endpoint()
     org = org(opts)
 
     case args do

--- a/lib/mix/tasks/nerves_hub.user.ex
+++ b/lib/mix/tasks/nerves_hub.user.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.NervesHub.User do
   use Mix.Task
 
+  import Mix.NervesHubCLI.Utils
+
   alias NervesHubCLI.{User, Config}
   alias Mix.NervesHubCLI.Shell
 
@@ -55,6 +57,8 @@ defmodule Mix.Tasks.NervesHub.User do
     Application.ensure_all_started(:nerves_hub_cli)
 
     {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
 
     case args do
       ["whoami"] ->


### PR DESCRIPTION
Currently, it's hard to tell which NervesHub server you're using. This
makes it more obvious.

NOTE: This requires a new release of `nerves_hub_cli`, so don't merge until that happens.