### PR TITLE
Support comma separated tags everywhere

### DIFF
--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -115,6 +115,46 @@ defmodule Mix.NervesHubCLI.Utils do
     for {key, val} <- map, do: {to_string(key), val}, into: %{}
   end
 
+  @doc """
+  Split up a string of comma-separated tags
+
+  Invalid tags raise.
+
+    iex> Mix.NervesHubCLI.Utils.split_tag_string("a, b, c")
+    ["a", "b", "c"]
+
+    iex> Mix.NervesHubCLI.Utils.split_tag_string("a space tag, b, c")
+    ** (RuntimeError) Tag 'a space tag' should not contain white space
+
+    iex> Mix.NervesHubCLI.Utils.split_tag_string("\\"tag_in_quotes\\"")
+    ** (RuntimeError) Tag '\"tag_in_quotes\"' should not contain quotes
+
+  """
+  @spec split_tag_string(String.t()) :: [String.t()]
+  def split_tag_string(str) do
+    tags =
+      str
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+
+    Enum.each(tags, &check_valid_tag/1)
+
+    tags
+  end
+
+  defp check_valid_tag(tag) do
+    cond do
+      String.contains?(tag, [" ", "\t", "\n"]) ->
+        raise "Tag '#{tag}' should not contain white space"
+
+      String.contains?(tag, ["\"", "'"]) ->
+        raise "Tag '#{tag}' should not contain quotes"
+
+      true ->
+        :ok
+    end
+  end
+
   defp config() do
     Mix.Project.config()
   end

--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -54,6 +54,9 @@ defmodule Mix.NervesHubCLI.Utils do
     org
   end
 
+  @doc """
+  Return the path to the generated firmware bundle
+  """
   @spec firmware() :: Path.t()
   def firmware do
     images_path =
@@ -64,6 +67,9 @@ defmodule Mix.NervesHubCLI.Utils do
     Path.join(images_path, filename)
   end
 
+  @doc """
+  Read the firmware metadata from the specified firmware bundle
+  """
   @spec metadata(Path.t()) :: {:error, any()} | {:ok, map()}
   def metadata(firmware) do
     case System.cmd("fwup", ["-m", "-i", firmware]) do
@@ -101,6 +107,10 @@ defmodule Mix.NervesHubCLI.Utils do
     end
   end
 
+  @doc """
+  Turn map keys into strings
+  """
+  @spec stringify(map()) :: map()
   def stringify(map) when is_map(map) do
     for {key, val} <- map, do: {to_string(key), val}, into: %{}
   end

--- a/lib/mix/tasks/nerves_hub.deployment.ex
+++ b/lib/mix/tasks/nerves_hub.deployment.ex
@@ -133,12 +133,13 @@ defmodule Mix.Tasks.NervesHub.Deployment do
     firmware = opts[:firmware] || Shell.prompt("Firmware uuid:")
     vsn = opts[:version] || Shell.prompt("Version condition:")
 
-    tags = Keyword.get_values(opts, :tag)
+    # Tags may be specified using multiple `--tag` options or as `--tag "a, b, c"`
+    tags = Keyword.get_values(opts, :tag) |> Enum.flat_map(&split_tag_string/1)
 
     tags =
       if tags == [] do
-        Shell.prompt("One or more device tags:")
-        |> String.split()
+        Shell.prompt("One or more comma-separated device tags:")
+        |> split_tag_string()
       else
         tags
       end

--- a/test/nerves_hub_cli_test.exs
+++ b/test/nerves_hub_cli_test.exs
@@ -1,4 +1,5 @@
 defmodule NervesHubCLITest do
   use ExUnit.Case
   doctest NervesHubCLI
+  doctest Mix.NervesHubCLI.Utils
 end


### PR DESCRIPTION
This should remove some confusion on comma vs. space separated tags.
The prompts now tell you to separate tags with commas and it errors out
if you try to have a space in a tag. While it had been possible to have
spaces in tags, it was really confusing to see them printed and when
they were added, it was an accident.

This also updates the `--tag` option so that if you pass `--tag a,b,c`,
it will turn into 3 tags. This is the same behavior as `--tag a --tag b
--tag c`, but shorter and without the need to parse tags in programs
calling `mix nerves_hub.device create`.