### PR TITLE
Include a device`s UUID for the device list task

### DIFF
--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -369,7 +369,16 @@ defmodule Mix.Tasks.NervesHub.Device do
 
   defp render_devices(org, devices) do
     title = "Devices for #{org}"
-    header = ["Identifier", "Tags", "Version", "Status", "Last connected", "Description"]
+
+    header = [
+      "Identifier",
+      "Tags",
+      "Version",
+      "Firmware UUID",
+      "Status",
+      "Last connected",
+      "Description"
+    ]
 
     rows =
       Enum.map(devices, fn device ->
@@ -377,6 +386,7 @@ defmodule Mix.Tasks.NervesHub.Device do
           device["identifier"],
           Enum.join(device["tags"], ", "),
           device["version"],
+          device["firmware_metadata"]["uuid"],
           device["status"],
           device["last_communication"],
           device["description"]


### PR DESCRIPTION
Include the device UUID in the `nerves_hub.device` list task report.

Issue #102 
Also required a change in `nerves_hub_web` to return the UUID: https://github.com/nerves-hub/nerves_hub_web/pull/454