### PR TITLE
Decouple :nerves_hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ command-line. Features include:
 * Manage user and organization accounts
 
 The recommended way of using the CLI is to include
-[`nerves_hub`](https://github.com/nerves-hub/nerves_hub) in your dependencies.
-`nerves_hub` pulls in `nerves_hub_cli` and includes the target runtime
+[`nerves_hub_link`](https://github.com/nerves-hub/nerves_hub_link) in your dependencies.
+`nerves_hub_link` pulls in `nerves_hub_cli` and includes the target runtime
 components necessary to use it.
 
 Once installed, you can access available commands and documentation from the
@@ -53,4 +53,4 @@ automation. The following variables are available:
 * `NERVES_HUB_NON_INTERACTIVE` - Force all yes/no user interaction to be yes
 
 For more information on using the CLI, see the
-[`nerves_hub`](https://github.com/nerves-hub/nerves_hub) documentation.
+[`nerves_hub_link`](https://github.com/nerves-hub/nerves_hub_link) documentation.

--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -27,7 +27,7 @@ defmodule Mix.NervesHubCLI.Utils do
     # not found
     org =
       Keyword.get(opts, :org) || System.get_env("NERVES_HUB_ORG") ||
-        Application.get_env(:nerves_hub, :org) || Config.get(:org) ||
+        org_from_env() || Config.get(:org) ||
         Shell.raise("""
         Cound not determine organization
         Organization is set in the following order
@@ -42,7 +42,7 @@ defmodule Mix.NervesHubCLI.Utils do
 
           By setting it in the project's config.exs
 
-            config :nerves_hub,
+            config :nerves_hub_cli,
               org: "org_name"
 
           Your user org from the NervesHub config
@@ -157,5 +157,20 @@ defmodule Mix.NervesHubCLI.Utils do
 
   defp config() do
     Mix.Project.config()
+  end
+
+  defp org_from_env() do
+    if Application.get_env(:nerves_hub, :org) do
+      Shell.raise("""
+
+      Using :nerves_hub env for your org is deprecated
+
+      Set it with:
+
+        config :nerves_hub_cli, org: "org_name"
+      """)
+    else
+      Application.get_env(:nerves_hub_cli, :org)
+    end
   end
 end

--- a/lib/nerves_hub_cli.ex
+++ b/lib/nerves_hub_cli.ex
@@ -30,11 +30,15 @@ defmodule NervesHubCLI do
   @doc """
   Convert a list of fwup public keys or references into a list of keys.
   """
-  @spec resolve_fwup_public_keys([fwup_public_key_ref()]) :: [binary()]
-  def resolve_fwup_public_keys([]), do: []
+  @spec resolve_fwup_public_keys([fwup_public_key_ref()], binary() | nil) :: [binary()]
+  def resolve_fwup_public_keys(keys, org \\ nil)
 
-  def resolve_fwup_public_keys(keys) when is_list(keys) do
-    org = Mix.NervesHubCLI.Utils.org([])
+  def resolve_fwup_public_keys([], _org), do: []
+
+  def resolve_fwup_public_keys(keys, org) when is_list(keys) do
+    opts = if is_bitstring(org), do: [org: org], else: []
+
+    org = Mix.NervesHubCLI.Utils.org(opts)
     local_keys = NervesHubCLI.Key.local_keys(org)
 
     Enum.reduce(keys, [], &[find_key(&1, local_keys) | &2])


### PR DESCRIPTION
For whatever reason, relying on a `:nerves_hub` config value for finding an org just doesn't jive with me.
So instead, lets look for `:nerves_hub_cli, :org` value to fetch from the project.

Also change `NervesHubCLI.resolve_fwup_public_keys/2` to allow supplying an org to use for the resolution.
This function is called from `:nerves_hub` and adding a second arg would allow `:nerves_hub` to handle
its own settings and pass its config values where needed to the CLI rather than coupling `:nerves_hub`
project config within `:nerves_hub_cli`

Once merged and released, I'll adjust `:nerves_hub` to use the new `NervesHubCLI.resolve_fwup_public_keys/2`