### PR TITLE
Improve error messages

### DIFF
--- a/lib/mix/tasks/nerves_hub.key.ex
+++ b/lib/mix/tasks/nerves_hub.key.ex
@@ -164,7 +164,12 @@ defmodule Mix.Tasks.NervesHub.Key do
 
   def create(name, org, opts) do
     if NervesHubCLI.Key.exists?(org, name) do
-      Shell.raise("The key '#{name}' already exists. Please choose a different name.")
+      Shell.raise("""
+      The key '#{name}' already exists.
+
+      Please choose a different name or delete by
+      running `mix nerves_hub.key delete #{name} [--local]`
+      """)
     else
       if Keyword.get(opts, :local, false) do
         with {:ok, key} <- create_local(name, org) do

--- a/lib/nerves_hub_cli/key.ex
+++ b/lib/nerves_hub_cli/key.ex
@@ -60,6 +60,12 @@ defmodule NervesHubCLI.Key do
          {:ok, encrypted_private_key} <- File.read(private_key_path),
          {:ok, private_key} <- Crypto.decrypt(encrypted_private_key, key_password) do
       {:ok, public_key, private_key}
+    else
+      {:error, :enoent} ->
+        {:error, "Couldn't find #{public_key_path} or #{private_key_path}"}
+
+      error ->
+        error
     end
   end
 


### PR DESCRIPTION
The key.ex one is more subtle than it looks. The error from that function, `{:error, :enoent}` propagated through quite a few functions before being printed so the context was lost. This makes it a little better. Fwiw, the root cause was that the organization I was using was set incorrectly. 