### PR TITLE
Add clause to print standard binary error messages

### DIFF
--- a/lib/mix/nerves_hub/shell.ex
+++ b/lib/mix/nerves_hub/shell.ex
@@ -107,6 +107,10 @@ defmodule Mix.NervesHubCLI.Shell do
     :ok
   end
 
+  def do_render_error({:error, reason}) when is_binary(reason) do
+    error(reason)
+  end
+
   def do_render_error({:error, %{"status" => "forbidden"}}) do
     error("Invalid credentials")
     error("Your user certificate has either expired or has been revoked.")


### PR DESCRIPTION
While investigating  #131, i noticed the error messages weren't be printed properly. This fixes that