### PR TITLE
Allow bas64 decoder to ignore whitespace

### DIFF
--- a/lib/mix/nerves_hub/shell.ex
+++ b/lib/mix/nerves_hub/shell.ex
@@ -140,7 +140,7 @@ defmodule Mix.NervesHubCLI.Shell do
   end
 
   defp try_decode64(value) do
-    case Base.decode64(value) do
+    case Base.decode64(value, ignore: :whitespace) do
       {:ok, value} -> value
       _ -> value
     end


### PR DESCRIPTION
The `base64` tool on linux can create whitespace in it's output