### PR TITLE
add some formatting to nerves_hub.device bulk_create

### DIFF
--- a/lib/mix/nerves_hub/bulk.ex
+++ b/lib/mix/nerves_hub/bulk.ex
@@ -2,45 +2,82 @@ defmodule Mix.NervesHubCLI.Bulk do
   alias Mix.NervesHubCLI.Shell
   import Mix.NervesHubCLI.Utils
 
+  @acc %{data: [], error: [], malformed: [], success: [], tasks: []}
+
   def create_devices(data, org, product, auth) do
-    data
-    |> Enum.filter(fn
-      [_identifier, _tags, _description] ->
-        true
+    %{@acc | data: data}
+    |> filter_malformed()
+    |> do_create_devices(org, product, auth)
+    |> accumulate_results()
+  end
 
-      _ ->
-        # maybe raise/exit here? 
-        false
-    end)
-    |> Enum.map(fn [identifier, tags, description] ->
-      tags = split_tag_string(tags)
+  def display_results(%{error: error, malformed: malformed, success: success}, csv_path) do
+    _ = Enum.each(error, &display_error/1)
 
-      Task.async(fn ->
-        result = NervesHubUserAPI.Device.create(org, product, identifier, description, tags, auth)
-        {result, [identifier, description, tags]}
-      end)
-    end)
-    |> Task.yield_many(:infinity)
-    |> Enum.filter(fn
-      {task, nil} ->
+    _ = Enum.each(malformed, &display_malformed(&1, csv_path))
+
+    Shell.info("""
+    Results:
+      #{IO.ANSI.yellow()}malformed: #{length(malformed)}
+      #{IO.ANSI.red()}errors: #{length(error)}
+      #{IO.ANSI.green()}successful: #{length(success)}
+    #{IO.ANSI.default_color()}
+    """)
+  end
+
+  defp accumulate_results(acc) do
+    Enum.reduce(acc.tasks, acc, fn
+      {task, nil}, acc ->
         _ = Task.shutdown(task, :brutal_kill)
-        false
+        acc
 
-      {_task, {:ok, {{:ok, %{} = _device}, _}}} ->
-        true
+      {_task, {:ok, {{:ok, %{} = device}, _}}}, acc ->
+        %{acc | success: [device | acc.success]}
 
-      {_task, {:ok, {error, [identifier, description, tags]}}} ->
-        Shell.error(
-          "Error creating #{identifier} with tags: #{inspect(tags)} and description: #{
-            description
-          }"
-        )
-
-        Shell.render_error(error, false)
-        false
+      {_task, {:ok, {_error, [_i, _d_, _t]} = err}}, acc ->
+        %{acc | error: [err | acc.error]}
     end)
-    |> Enum.map(fn {_task, {:ok, {{:ok, %{} = device}, _}}} ->
-      device
+  end
+
+  defp display_error({error, [identifier, description, tags]}) do
+    Shell.error("""
+    Error creating #{identifier} with tags: #{inspect(tags)} and description: #{description} ¬
+      #{inspect(error)}
+    """)
+  end
+
+  defp display_malformed({line, line_num}, csv_path) do
+    Shell.info("""
+    #{IO.ANSI.yellow()} Malformed CSV line - #{inspect(line)}
+      (CSV) #{csv_path}:#{line_num}
+    #{IO.ANSI.default_color()}
+    """)
+  end
+
+  defp do_create_devices(acc, org, product, auth) do
+    tasks =
+      Enum.map(acc.data, fn [identifier, tags, description] ->
+        tags = split_tag_string(tags)
+
+        Task.async(fn ->
+          result =
+            NervesHubUserAPI.Device.create(org, product, identifier, description, tags, auth)
+
+          {result, [identifier, description, tags]}
+        end)
+      end)
+
+    %{acc | tasks: Task.yield_many(tasks, :infinity)}
+  end
+
+  defp filter_malformed(acc) do
+    Enum.with_index(acc.data)
+    |> Enum.reduce(%{acc | data: []}, fn
+      {[_identifier, _tags, _description] = line, _i}, acc ->
+        %{acc | data: [line | acc.data]}
+
+      {_line, _line_num} = bad_line, acc ->
+        %{acc | malformed: [bad_line | acc.malformed]}
     end)
   end
 end

--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -286,7 +286,7 @@ defmodule Mix.Tasks.NervesHub.Device do
     end
   end
 
-  @spec bulk_create(String.t(), String.t(), keyword()) :: [any()]
+  @spec bulk_create(String.t(), String.t(), keyword()) :: :ok
   def bulk_create(org, product, args) do
     auth = Shell.request_auth()
     path = args[:csv]
@@ -303,6 +303,7 @@ defmodule Mix.Tasks.NervesHub.Device do
     |> CSV.parse_stream()
     |> Enum.to_list()
     |> Bulk.create_devices(org, product, auth)
+    |> Bulk.display_results(path)
   end
 
   @spec update(String.t(), String.t(), String.t(), [String.t()]) :: :ok


### PR DESCRIPTION
After using this a bit, I thought it would be nice to have some useful results output. So this adds that 🎉 

Specifically:
* Reports error details per device
* Shows when the CSV line is unexpected format and tries to deduce line number for the malformed line
* General report at the end with number of errors, malformed lines, and successful requests

![bulk-report](https://user-images.githubusercontent.com/11321326/89930044-5c325a00-dbc7-11ea-95fc-a1c0842406d1.png)
