### PR TITLE
Support CA Certificate serial as hex

### DIFF
--- a/lib/mix/nerves_hub/utils.ex
+++ b/lib/mix/nerves_hub/utils.ex
@@ -142,6 +142,25 @@ defmodule Mix.NervesHubCLI.Utils do
     tags
   end
 
+  @doc """
+  Takes the integer serial representation of a certificate serial number
+  and converts it to a hex string with `:` separators to match typical
+  output from OpenSSL
+  """
+  @spec serial_as_hex(binary | integer) :: binary
+  def serial_as_hex(serial_int) when is_integer(serial_int) do
+    serial_int
+    |> Integer.to_string(16)
+    |> to_charlist()
+    |> Enum.chunk_every(2)
+    |> Enum.join(":")
+  end
+
+  def serial_as_hex(serial_str) when is_binary(serial_str) do
+    String.to_integer(serial_str)
+    |> serial_as_hex()
+  end
+
   defp check_valid_tag(tag) do
     cond do
       String.contains?(tag, [" ", "\t", "\n"]) ->

--- a/lib/mix/tasks/nerves_hub.ca_certificate.ex
+++ b/lib/mix/tasks/nerves_hub.ca_certificate.ex
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.NervesHub.CaCertificate do
          description <- Keyword.get(opts, :description),
          {:ok, %{"data" => %{"serial" => serial}}} <-
            NervesHubUserAPI.CACertificate.create(org, cert_pem, auth, description) do
-      Shell.info("CA certificate '#{serial}' registered.")
+      Shell.info("CA certificate '#{serial_as_hex(serial)}' registered.")
     else
       error ->
         Shell.render_error(error)
@@ -98,6 +98,8 @@ defmodule Mix.Tasks.NervesHub.CaCertificate do
     if Shell.yes?("Unregister CA certificate '#{serial}'?") do
       auth = Shell.request_auth()
       Shell.info("Unregistering CA certificate '#{serial}'")
+
+      serial = if String.contains?(serial, ":"), do: serial_from_hex(serial), else: serial
 
       case NervesHubUserAPI.CACertificate.delete(org, serial, auth) do
         {:ok, ""} ->
@@ -134,8 +136,15 @@ defmodule Mix.Tasks.NervesHub.CaCertificate do
 
     """
       serial:      #{params["serial"]}
+      serial hex:  #{serial_as_hex(params["serial"])}
       validity:    #{DateTime.to_date(not_before)} - #{DateTime.to_date(not_after)} UTC
       description: #{params["description"]}
     """
+  end
+
+  defp serial_from_hex(hex) do
+    String.replace(hex, ":", "")
+    |> String.to_integer(16)
+    |> to_string()
   end
 end

--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -474,7 +474,7 @@ defmodule Mix.Tasks.NervesHub.Device do
          auth <- Shell.request_auth(),
          {:ok, %{"data" => %{"serial" => serial}}} <-
            NervesHubUserAPI.DeviceCertificate.create(org, product, identifier, cert_pem, auth) do
-      Shell.info("Device certificate '#{serial}' registered.")
+      Shell.info("Device certificate '#{serial_as_hex(serial)}' registered.")
     else
       error ->
         Shell.render_error(error)
@@ -504,6 +504,7 @@ defmodule Mix.Tasks.NervesHub.Device do
 
     """
       serial:     #{params["serial"]}
+      serial hex: #{serial_as_hex(params["serial"])}
       validity:   #{DateTime.to_date(not_before)} - #{DateTime.to_date(not_after)} UTC
     """
   end


### PR DESCRIPTION
The web UI was recently changed to display certificate serial numbers as hex. This updates `nerves_hub.ca_certificate` functions to also display the serial as hex as well. It also adjusts `nerves_hub.ca_certificate unregister` to support using the hex or interger representation of the serial as well