### PR TITLE
Fix error rendering devices without a tag

### DIFF
--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -527,7 +527,7 @@ defmodule Mix.Tasks.NervesHub.Device do
       Enum.map(devices, fn device ->
         [
           device["identifier"],
-          Enum.join(device["tags"], ", "),
+          Enum.join(device["tags"] || [], ", "),
           device["version"],
           device["firmware_metadata"]["uuid"],
           device["status"],
@@ -548,7 +548,9 @@ defmodule Mix.Tasks.NervesHub.Device do
   end
 
   defp filter_devices(device, [{:tag, tag} | rest]) do
-    if Enum.any?(device["tags"], fn device_tag -> device_tag == tag end),
+    tags = device["tags"] || []
+
+    if Enum.any?(tags, fn device_tag -> device_tag == tag end),
       do: filter_devices(device, rest)
   end
 


### PR DESCRIPTION
This fixes errors like the one below which are caused by devices not having any tags (or `tags: nil`)

```
jonjon@bender:~/repos/nerves_hub_cli$ mix nerves_hub.device list --product poser
NervesHub server: 0.0.0.0:4002
NervesHub organization: jonjon
Local NervesHub user password:
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): GenEvent.Stream, HashDict, MapSet, Function, Date.Range, List, HashSet, Stream, Range, IO.Stream, File.Stream, Map
    (elixir 1.11.2) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.11.2) lib/enum.ex:141: Enumerable.reduce/3
    (elixir 1.11.2) lib/enum.ex:3461: Enum.join/2
    (nerves_hub_cli 0.10.4) lib/mix/tasks/nerves_hub.device.ex:530: anonymous fn/1 in Mix.Tasks.NervesHub.Device.render_devices/3
    (elixir 1.11.2) lib/enum.ex:1399: Enum."-map/2-lists^map/1-0-"/2
    (elixir 1.11.2) lib/enum.ex:1399: Enum."-map/2-lists^map/1-0-"/2
    (nerves_hub_cli 0.10.4) lib/mix/tasks/nerves_hub.device.ex:527: Mix.Tasks.NervesHub.Device.render_devices/3
    (nerves_hub_cli 0.10.4) lib/mix/tasks/nerves_hub.device.ex:255: Mix.Tasks.NervesHub.Device.list/3
```