### PR TITLE
Remove uses of @data-dir

### DIFF
--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -181,8 +181,6 @@ defmodule Mix.Tasks.NervesHub.Device do
     csv: :string
   ]
 
-  @data_dir "nerves-hub"
-
   @spec run([String.t()]) :: :ok | no_return()
   def run(args) do
     _ = Application.ensure_all_started(:nerves_hub_cli)
@@ -367,7 +365,7 @@ defmodule Mix.Tasks.NervesHub.Device do
 
   @spec burn(String.t(), keyword()) :: :ok
   def burn(identifier, opts) do
-    path = opts[:path] || Path.join(File.cwd!(), @data_dir)
+    path = opts[:path] || NervesHubCLI.home_dir()
     cert_path = opts[:cert]
     key_path = opts[:key]
 
@@ -432,7 +430,7 @@ defmodule Mix.Tasks.NervesHub.Device do
         ) :: :ok
   def cert_create(org, product, identifier, opts, auth \\ nil) do
     Shell.info("Creating certificate for #{identifier}")
-    path = opts[:path] || Path.join(File.cwd!(), @data_dir)
+    path = opts[:path] || NervesHubCLI.home_dir()
     File.mkdir_p!(path)
 
     key = X509.PrivateKey.new_ec(:secp256r1)

--- a/lib/mix/tasks/nerves_hub.key.ex
+++ b/lib/mix/tasks/nerves_hub.key.ex
@@ -89,7 +89,6 @@ defmodule Mix.Tasks.NervesHub.Key do
     path: :string,
     local: :boolean
   ]
-  @data_dir "nerves-hub"
 
   def run(args) do
     _ = Application.ensure_all_started(:nerves_hub_cli)
@@ -234,7 +233,7 @@ defmodule Mix.Tasks.NervesHub.Key do
   end
 
   def export(key, org, opts) do
-    path = opts[:path] || Path.join(File.cwd!(), @data_dir)
+    path = opts[:path] || NervesHubCLI.home_dir()
 
     with :ok <- File.mkdir_p(path),
          {:ok, public_key, private_key} <- Shell.request_keys(org, key),

--- a/lib/mix/tasks/nerves_hub.user.ex
+++ b/lib/mix/tasks/nerves_hub.user.ex
@@ -51,7 +51,6 @@ defmodule Mix.Tasks.NervesHub.User do
   """
 
   @switches [path: :string]
-  @data_dir "nerves-hub"
 
   def run(args) do
     _ = Application.ensure_all_started(:nerves_hub_cli)
@@ -156,7 +155,7 @@ defmodule Mix.Tasks.NervesHub.User do
   end
 
   def cert_export(opts) do
-    path = opts[:path] || Path.join(File.cwd!(), @data_dir)
+    path = opts[:path] || NervesHubCLI.home_dir()
     password = Shell.password_get("Local user password:")
 
     with :ok <- File.mkdir_p(path),


### PR DESCRIPTION
This module attribute was defaulting the `nerves-hub` dir of the current
directory in a few places. However, this breaks the expectation when
setting `:home_dir` or `NERVES_HUB_HOME`.

This changes removes the module attribute in those places and uses
`NervesHubCLI.home_dir/0` instead