### PR TITLE
Avoid broken pbcs 0.1.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule NervesHubCLI.MixProject do
 
   defp deps do
     [
-      {:pbcs, "~> 0.1"},
+      # Avoid broken pbcs 0.1.3 version
+      {:pbcs, "== 0.1.2 or ~> 0.1.4"},
       {:x509, "~> 0.3"},
       {:nerves_hub_user_api, "~> 0.8.0"},
       {:table_rex, "~> 2.0.0 or ~> 3.0"},


### PR DESCRIPTION
`mix deps.update --all` will still download `pbcs 0.1.3`. It shows a
warning, but some people ignore it. This prevents 0.1.3 from being used.
