### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ install_hex_rebar: &install_hex_rebar
 jobs:
   build:
     docker:
-      - image: hexpm/elixir:1.13.4-erlang-24.3.3-alpine-3.14.5
+      - image: hexpm/elixir:1.13.4-erlang-25.0-alpine-3.15.4
     <<: *defaults
     steps:
       - checkout

--- a/lib/mix/tasks/nerves_hub.device.ex
+++ b/lib/mix/tasks/nerves_hub.device.ex
@@ -488,7 +488,7 @@ defmodule Mix.Tasks.NervesHub.Device do
     Enum.each(certs, fn params ->
       Shell.info("------------")
 
-      render_certs(identifier, params)
+      render_cert(identifier, params)
       |> String.trim_trailing()
       |> Shell.info()
     end)
@@ -497,7 +497,7 @@ defmodule Mix.Tasks.NervesHub.Device do
     Shell.info("")
   end
 
-  defp render_certs(_identifier, params) do
+  defp render_cert(_identifier, params) do
     {:ok, not_before, _} = DateTime.from_iso8601(params["not_before"])
 
     {:ok, not_after, _} = DateTime.from_iso8601(params["not_after"])

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule NervesHubCLI.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs],
+      flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling, :underspecs],
       plt_add_apps: [:public_key, :asn1, :crypto, :mix],
       ignore_warnings: "dialyzer.ignore-warnings"
     ]


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions