### PR TITLE
Remove signing devices (and users) by NervesHubWeb

### DIFF
--- a/lib/nerves_hub_cli/api/device.ex
+++ b/lib/nerves_hub_cli/api/device.ex
@@ -87,11 +87,6 @@ defmodule NervesHubCLI.API.Device do
     DeviceCertificate.list(org_name, product_name, device_identifier, auth)
   end
 
-  @deprecated "use NervesHubCLI.API.DeviceCertificate.sign/5 instead"
-  def cert_sign(org_name, product_name, device_identifier, csr, %Auth{} = auth) do
-    DeviceCertificate.sign(org_name, product_name, device_identifier, csr, auth)
-  end
-
   @doc false
   @spec path(String.t(), String.t()) :: String.t()
   def path(org_name, product_name) do

--- a/lib/nerves_hub_cli/api/device_certificate.ex
+++ b/lib/nerves_hub_cli/api/device_certificate.ex
@@ -24,20 +24,6 @@ defmodule NervesHubCLI.API.DeviceCertificate do
   end
 
   @doc """
-  Sign a new certificate signing request for a device.
-
-  Verb: POST
-  Path: /orgs/:org_name/products/:product_name/devices/:device_identifier/certificates/sign
-  """
-  @spec sign(String.t(), String.t(), String.t(), String.t(), NervesHubCLI.API.Auth.t()) ::
-          {:error, any()} | {:ok, any()}
-  def sign(org_name, product_name, device_identifier, csr, %Auth{} = auth) do
-    params = %{identifier: device_identifier, csr: csr}
-    path = Path.join(path(org_name, product_name, device_identifier), "sign")
-    API.request(:post, path, params, auth)
-  end
-
-  @doc """
   Upload a trusted certificate for a device.
 
   Verb: POST

--- a/lib/nerves_hub_cli/api/user.ex
+++ b/lib/nerves_hub_cli/api/user.ex
@@ -65,16 +65,4 @@ defmodule NervesHubCLI.API.User do
     {:ok, hostname} = :inet.gethostname()
     to_string(hostname)
   end
-
-  @doc """
-  Sign a user certificate for an existing user.
-
-  Verb: POST
-  Path: /users/sign
-  """
-  @spec sign(String.t(), String.t(), String.t(), String.t()) :: {:error, any()} | {:ok, any()}
-  def sign(email, password, csr, description) do
-    params = %{email: email, password: password, csr: csr, description: description}
-    API.request(:post, "users/sign", params)
-  end
 end


### PR DESCRIPTION
This requires NervesHubCA which is deprecated.