### PR TITLE
prefer http1 for file uploads

### DIFF
--- a/lib/nerves_hub_cli/api.ex
+++ b/lib/nerves_hub_cli/api.ex
@@ -105,7 +105,9 @@ defmodule NervesHubCLI.API do
 
     [
       ssl_options: ssl_options,
-      recv_timeout: 60_000
+      recv_timeout: 60_000,
+      protocols: [:http1],
+      timeout: 300_000
     ]
   end
 


### PR DESCRIPTION
http2 file uploads were causing consistent errors due to the window size not being updated by the mint adapter

https://github.com/elixir-tesla/tesla/issues/394

this change locks the api to use http1, with a timeout of 5mins (large uploads)