### PR TITLE
support a slightly simpler config for host, port, and scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,19 @@ automation. The following variables are available:
 * `NERVES_HUB_FW_PRIVATE_KEY` - Fwup signing private key
 * `NERVES_HUB_FW_PUBLIC_KEY`  - Fwup signing public key
 * `NERVES_HUB_HOME` - NervesHub CLI data directory (defaults to `~/.nerves-hub`)
-* `NERVES_HUB_HOST` - NervesHub API endpoint IP address or hostname (defaults to `api.nerves-hub.org`)
-* `NERVES_HUB_PORT` - NervesHub API endpoint port (defaults to 443)
+* `NERVES_HUB_URI` - NervesHub API host, port, scheme (all in one)
+* `NERVES_HUB_HOST` - NervesHub API endpoint IP address or hostname
+* `NERVES_HUB_PORT` - NervesHub API endpoint port
+* `NERVES_HUB_SCHEME` - NervesHub API endpoint scheme
 * `NERVES_HUB_NON_INTERACTIVE` - Force all yes/no user interaction to be yes
 
 For more information on using the CLI, see the
 [`nerves_hub_link`](https://github.com/nerves-hub/nerves_hub_link) documentation.
 
-## Connecting to other environments
+## Connecting to NervesHub
 
-NervesHubCLI can be directed to target other environments beside the public
-NervesHub instance. See the
+NervesHubCLI must be configured to connect to your chosen NervesHub host.
+
+See the
 [documentation](https://docs.nerves-hub.org/nerves-hub/setup/connecting-other-envs)
 for example config values to do this.

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,3 @@
 import Config
 
 config :logger, level: :info
-
-# Import environment specific config. This must remain at the bottom
-# of this file so it overrides the configuration defined above.
-import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,0 @@
-import Config
-
-config :nerves_hub_cli,
-  home_dir: Path.expand(".nerves-hub"),
-  scheme: "http",
-  host: "localhost",
-  port: 4000

--- a/config/docs.exs
+++ b/config/docs.exs
@@ -1,1 +1,0 @@
-import Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,5 +1,0 @@
-import Config
-
-config :nerves_hub_cli,
-  host: "api.nerves-hub.org",
-  port: 443

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -1,6 +1,0 @@
-import Config
-
-config :nerves_hub_cli,
-  home_dir: Path.expand(".nerves-hub"),
-  host: "api.staging.nerves-hub.org",
-  port: 443

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,0 @@
-import Config
-
-config :nerves_hub_cli,
-  home_dir: Path.expand("test/.nerves-hub"),
-  scheme: "http",
-  host: "0.0.0.0",
-  port: 4002

--- a/lib/nerves_hub_cli/api.ex
+++ b/lib/nerves_hub_cli/api.ex
@@ -19,11 +19,18 @@ defmodule NervesHubCLI.API do
   @spec endpoint() :: String.t()
   def endpoint() do
     opts = Application.get_all_env(:nerves_hub_cli)
-    scheme = System.get_env("NERVES_HUB_SCHEME") || opts[:scheme]
-    host = System.get_env("NERVES_HUB_HOST") || opts[:host]
-    port = get_env_as_integer("NERVES_HUB_PORT") || opts[:port]
 
-    %URI{scheme: scheme, host: host, port: port, path: "/api"} |> URI.to_string()
+    if server = System.get_env("NERVES_HUB_URI") || opts[:uri] do
+      URI.parse(server)
+      |> URI.append_path("/api")
+      |> URI.to_string()
+    else
+      scheme = System.get_env("NERVES_HUB_SCHEME") || opts[:scheme]
+      host = System.get_env("NERVES_HUB_HOST") || opts[:host]
+      port = get_env_as_integer("NERVES_HUB_PORT") || opts[:port]
+
+      %URI{scheme: scheme, host: host, port: port, path: "/api"} |> URI.to_string()
+    end
   end
 
   def request(:get, path, params) when is_map(params) do


### PR DESCRIPTION
- remove nerves-hub.org defaults
- remove mention of these defaults in the readme
- remove the environment configs, they aren't used
- and support a `uri` config which includes all the host, port, scheme bits needed