### PR TITLE
Support a globally-installable escript

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,6 @@ tags: &tags
     1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.5-erlang-25.3.2.7-alpine-3.18.4,
     1.13.4-erlang-25.3.2.7-alpine-3.18.4,
-    1.12.3-erlang-24.3.4.14-alpine-3.18.4,
-    1.11.4-erlang-23.3.4.19-alpine-3.16.7
   ]
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ nerves_hub_cli-*.tar
 # Ignore any nerves-hub certificates
 /nerves-hub
 /*.pem
+
+# Ignore escript binary
+nerves_hub

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ This is the 2.0 development branch of NervesHubCLI. If you have been using Nerve
 
 ---
 
-`NervesHubCLI` provides a set of [Mix](https://hexdocs.pm/mix/Mix.html) tasks so
-that you can work with [NervesHub](https://www.nerves-hub.org) from the
-command-line. Features include:
+`NervesHubCLI` is an [escript](https://hexdocs.pm/mix/main/Mix.Tasks.Escript.Build.html) 
+CLI tool for working with [NervesHub](https://www.nerves-hub.org) from the command-line. 
+Features include:
 
 * Uploading firmware to NervesHub
 * Generating device certificates and registration
@@ -20,28 +20,18 @@ command-line. Features include:
 * Manage firmware deployments
 * Manage user and organization accounts
 
-The recommended way of using the CLI is to include
-[`nerves_hub_link`](https://github.com/nerves-hub/nerves_hub_link) in your dependencies.
-`nerves_hub_link` pulls in `nerves_hub_cli` and includes the target runtime
-components necessary to use it.
+The recommended way of using the CLI is to run `mix escript.install hex nerves_hub_cli`. 
+Note that you may have to add the binary installation directory to your PATH
 
 Once installed, you can access available commands and documentation from the
-command-line using `mix help`:
+command-line using `nerves_hub help`:
 
 ```sh
-$ mix help
-...
-mix nerves_hub.deployment # Manages NervesHub deployments
-mix nerves_hub.device     # Manages your NervesHub devices
-mix nerves_hub.firmware   # Manages firmware on NervesHub
-mix nerves_hub.key        # Manages your firmware signing keys
-mix nerves_hub.product    # Manages your products
-mix nerves_hub.user       # Manages your NervesHub user account
-...
-
-$ mix help nerves_hub.device
-...
+$ nerves_hub help
+$ nerves_hub help device
 ```
+
+To uninstall, run `mix escript.uninstall nerves_hub_cli`.
 
 ## Environment variables
 
@@ -68,6 +58,15 @@ For more information on using the CLI, see the
 
 NervesHubCLI must be configured to connect to your chosen NervesHub host.
 
-See the
-[documentation](https://docs.nerves-hub.org/nerves-hub/setup/connecting-other-envs)
-for example config values to do this.
+To configure the NervesHub URI, run:
+
+```sh
+$ nerves_hub config set uri "https://my.nerveshub.instance/"
+```
+
+Finally, you need to authorize your account on the NervesHub instance by running:
+
+```sh
+$ nerves_hub user whoami
+$ nerves_hub user auth
+```

--- a/lib/mix/tasks/nerves_hub.firmware.ex
+++ b/lib/mix/tasks/nerves_hub.firmware.ex
@@ -81,10 +81,6 @@ defmodule Mix.Tasks.NervesHub.Firmware do
       ["list"] ->
         list(org, product)
 
-      ["publish" | []] ->
-        firmware()
-        |> publish_confirm(org, opts)
-
       ["publish", firmware] when is_binary(firmware) ->
         firmware
         |> Path.expand()
@@ -92,10 +88,6 @@ defmodule Mix.Tasks.NervesHub.Firmware do
 
       ["delete", uuid] when is_binary(uuid) ->
         delete_confirm(uuid, org, product)
-
-      ["sign"] ->
-        firmware()
-        |> sign(org, opts)
 
       ["sign", firmware] ->
         sign(firmware, org, opts)

--- a/lib/nerves_hub_cli/api.ex
+++ b/lib/nerves_hub_cli/api.ex
@@ -157,11 +157,12 @@ defmodule NervesHubCLI.API do
       is_atom(ca_store) and !is_nil(ca_store) ->
         ca_store.ca_certs()
 
-      Code.ensure_loaded?(CAStore) ->
-        CAStore.file_path()
-        |> File.read!()
-        |> X509.from_pem()
-        |> Enum.map(&X509.Certificate.to_der/1)
+      # CAStore uses the priv directory, which does not work with escripts
+      # Code.ensure_loaded?(CAStore) ->
+      #   CAStore.file_path()
+      #   |> File.read!()
+      #   |> X509.from_pem()
+      #   |> Enum.map(&X509.Certificate.to_der/1)
 
       true ->
         :public_key.cacerts_get()

--- a/lib/nerves_hub_cli/api.ex
+++ b/lib/nerves_hub_cli/api.ex
@@ -20,7 +20,7 @@ defmodule NervesHubCLI.API do
   def endpoint() do
     opts = Application.get_all_env(:nerves_hub_cli)
 
-    if server = System.get_env("NERVES_HUB_URI") || opts[:uri] do
+    if server = System.get_env("NERVES_HUB_URI") || opts[:uri] || NervesHubCLI.Config.get(:uri) do
       URI.parse(server)
       |> URI.append_path("/api")
       |> URI.to_string()

--- a/lib/nerves_hub_cli/cli.ex
+++ b/lib/nerves_hub_cli/cli.ex
@@ -19,14 +19,14 @@ defmodule NervesHubCLI.CLI do
 
   def main(_args) do
     """
-    This is nerves_hub_cli, the command line app to manage NervesHub resources.
+    This is nerves_hub CLI, the command line app to manage NervesHub resources.
 
     Usage:
       #{executable()} <command> <subcommand> [flags] 
 
     Commands:
       user:\t\t\tManage your NervesHub user account
-      config:\t\tManage CLI configuration options which are persisted between calls
+      config:\t\tSet the global configuration for NervesHub CLI
       certificate:\t\tManage CA certificates for validating device connections
       deployment:\t\tManage NervesHub deployments
       device:\t\tManage your NervesHub devices

--- a/lib/nerves_hub_cli/cli.ex
+++ b/lib/nerves_hub_cli/cli.ex
@@ -25,16 +25,16 @@ defmodule NervesHubCLI.CLI do
       #{executable()} <command> <subcommand> [flags] 
 
     Commands:
-      user:\t\t\tManage your NervesHub user account
-      config:\t\tSet the global configuration for NervesHub CLI
-      certificate:\t\tManage CA certificates for validating device connections
-      deployment:\t\tManage NervesHub deployments
-      device:\t\tManage your NervesHub devices
-      firmware:\t\tManage firmware on NervesHub
-      key:\t\t\tManage firmware signing keys
-      org:\t\t\tManages an organization
-      product:\t\tManages your products on NervesHub
-      help:\t\t\tPrints this message
+      user:           Manage the signed in NervesHub user
+      config:         Manage the global configuration for NervesHub CLI
+      certificate:    Manage CA certificates for validating device connections
+      deployment:     Manage deployments on NervesHub
+      device:         Manage devices on NervesHub
+      firmware:       Manage firmware on NervesHub
+      key:            Manage firmware signing keys
+      org:            Manage a NervesHub organization
+      product:        Manage products on NervesHub
+      help:           Prints this message
 
     To get more information about a specific command, run:
     #{executable()} help <command>

--- a/lib/nerves_hub_cli/cli.ex
+++ b/lib/nerves_hub_cli/cli.ex
@@ -7,7 +7,7 @@ defmodule NervesHubCLI.CLI do
     case command do
       "ca_certificate" -> NervesHubCLI.CLI.CaCertificate.run(args)
       "deployment" -> NervesHubCLI.CLI.Deployment.run(args)
-      "device" -> Mix.Tasks.NervesHub.Device.run(args)
+      "device" -> NervesHubCLI.CLI.Device.run(args)
       "firmware" -> NervesHubCLI.CLI.Firmware.run(args)
       "key" -> NervesHubCLI.CLI.Key.run(args)
       "org" -> NervesHubCLI.CLI.Org.run(args)

--- a/lib/nerves_hub_cli/cli.ex
+++ b/lib/nerves_hub_cli/cli.ex
@@ -1,7 +1,7 @@
 defmodule NervesHubCLI.CLI do
   alias NervesHubCLI.CLI.Shell
 
-  @valid_commands ~w"certificate deployment device firmware key org product user help"
+  @valid_commands ~w"certificate deployment device firmware key org product user help config"
 
   def main([command | args]) when command in @valid_commands do
     case command do
@@ -10,9 +10,10 @@ defmodule NervesHubCLI.CLI do
       "device" -> Mix.Tasks.NervesHub.Device.run(args)
       "firmware" -> Mix.Tasks.NervesHub.Firmware.run(args)
       "key" -> NervesHubCLI.CLI.Key.run(args)
-      "org" -> Mix.Tasks.NervesHub.Org.run(args)
+      "org" -> NervesHubCLI.CLI.Org.run(args)
       "product" -> Mix.Tasks.NervesHub.Product.run(args)
       "user" -> NervesHubCLI.CLI.User.run(args)
+      "config" -> NervesHubCLI.CLI.Config.run(args)
     end
   end
 

--- a/lib/nerves_hub_cli/cli.ex
+++ b/lib/nerves_hub_cli/cli.ex
@@ -11,7 +11,7 @@ defmodule NervesHubCLI.CLI do
       "firmware" -> Mix.Tasks.NervesHub.Firmware.run(args)
       "key" -> NervesHubCLI.CLI.Key.run(args)
       "org" -> NervesHubCLI.CLI.Org.run(args)
-      "product" -> Mix.Tasks.NervesHub.Product.run(args)
+      "product" -> NervesHubCLI.CLI.Product.run(args)
       "user" -> NervesHubCLI.CLI.User.run(args)
       "config" -> NervesHubCLI.CLI.Config.run(args)
     end

--- a/lib/nerves_hub_cli/cli.ex
+++ b/lib/nerves_hub_cli/cli.ex
@@ -6,9 +6,9 @@ defmodule NervesHubCLI.CLI do
   def main([command | args]) when command in @valid_commands do
     case command do
       "ca_certificate" -> Mix.Tasks.NervesHub.CaCertificate.run(args)
-      "deployment" -> Mix.Tasks.NervesHub.Deployment.run(args)
+      "deployment" -> NervesHubCLI.CLI.Deployment.run(args)
       "device" -> Mix.Tasks.NervesHub.Device.run(args)
-      "firmware" -> Mix.Tasks.NervesHub.Firmware.run(args)
+      "firmware" -> NervesHubCLI.CLI.Firmware.run(args)
       "key" -> NervesHubCLI.CLI.Key.run(args)
       "org" -> NervesHubCLI.CLI.Org.run(args)
       "product" -> NervesHubCLI.CLI.Product.run(args)

--- a/lib/nerves_hub_cli/cli.ex
+++ b/lib/nerves_hub_cli/cli.ex
@@ -1,0 +1,50 @@
+defmodule NervesHubCLI.CLI do
+  alias NervesHubCLI.CLI.Shell
+
+  @valid_commands ~w"certificate deployment device firmware key org product user help"
+
+  def main([command | args]) when command in @valid_commands do
+    case command do
+      "ca_certificate" -> Mix.Tasks.NervesHub.CaCertificate.run(args)
+      "deployment" -> Mix.Tasks.NervesHub.Deployment.run(args)
+      "device" -> Mix.Tasks.NervesHub.Device.run(args)
+      "firmware" -> Mix.Tasks.NervesHub.Firmware.run(args)
+      "key" -> NervesHubCLI.CLI.Key.run(args)
+      "org" -> Mix.Tasks.NervesHub.Org.run(args)
+      "product" -> Mix.Tasks.NervesHub.Product.run(args)
+      "user" -> NervesHubCLI.CLI.User.run(args)
+    end
+  end
+
+  def main(_args) do
+    """
+    This is nerves_hub_cli, the command line app to manage NervesHub resources.
+
+    Usage:
+      #{executable()} <command> <subcommand> [flags] 
+
+    Commands:
+      user:\t\t\tManage your NervesHub user account
+      config:\t\tManage CLI configuration options which are persisted between calls
+      certificate:\t\tManage CA certificates for validating device connections
+      deployment:\t\tManage NervesHub deployments
+      device:\t\tManage your NervesHub devices
+      firmware:\t\tManage firmware on NervesHub
+      key:\t\t\tManage firmware signing keys
+      org:\t\t\tManages an organization
+      product:\t\tManages your products on NervesHub
+      help:\t\t\tPrints this message
+
+    To get more information about a specific command, run:
+    #{executable()} help <command>
+
+    Examples:
+      $ #{executable()} user auth
+      $ #{executable()} device list
+      $ #{executable()} key create --name dev_key
+    """
+    |> Shell.info()
+  end
+
+  defp executable, do: "nerves_hub"
+end

--- a/lib/nerves_hub_cli/cli.ex
+++ b/lib/nerves_hub_cli/cli.ex
@@ -1,11 +1,11 @@
 defmodule NervesHubCLI.CLI do
   alias NervesHubCLI.CLI.Shell
 
-  @valid_commands ~w"certificate deployment device firmware key org product user help config"
+  @valid_commands ~w"ca_certificate deployment device firmware key org product user help config"
 
   def main([command | args]) when command in @valid_commands do
     case command do
-      "ca_certificate" -> Mix.Tasks.NervesHub.CaCertificate.run(args)
+      "ca_certificate" -> NervesHubCLI.CLI.CaCertificate.run(args)
       "deployment" -> NervesHubCLI.CLI.Deployment.run(args)
       "device" -> Mix.Tasks.NervesHub.Device.run(args)
       "firmware" -> NervesHubCLI.CLI.Firmware.run(args)

--- a/lib/nerves_hub_cli/cli/bulk.ex
+++ b/lib/nerves_hub_cli/cli/bulk.ex
@@ -1,0 +1,83 @@
+defmodule NervesHubCLI.CLI.Bulk do
+  alias NervesHubCLI.CLI.Shell
+  import NervesHubCLI.CLI.Utils
+
+  @acc %{data: [], error: [], malformed: [], success: [], tasks: []}
+
+  def create_devices(data, org, product, auth) do
+    %{@acc | data: data}
+    |> filter_malformed()
+    |> do_create_devices(org, product, auth)
+    |> accumulate_results()
+  end
+
+  def display_results(%{error: error, malformed: malformed, success: success}, csv_path) do
+    _ = Enum.each(error, &display_error/1)
+
+    _ = Enum.each(malformed, &display_malformed(&1, csv_path))
+
+    Shell.info("""
+    Results:
+      #{IO.ANSI.yellow()}malformed: #{length(malformed)}
+      #{IO.ANSI.red()}errors: #{length(error)}
+      #{IO.ANSI.green()}successful: #{length(success)}
+    #{IO.ANSI.default_color()}
+    """)
+  end
+
+  defp accumulate_results(acc) do
+    Enum.reduce(acc.tasks, acc, fn
+      {task, nil}, acc ->
+        _ = Task.shutdown(task, :brutal_kill)
+        acc
+
+      {_task, {:ok, {{:ok, %{} = device}, _}}}, acc ->
+        %{acc | success: [device | acc.success]}
+
+      {_task, {:ok, {_error, [_i, _d_, _t]} = err}}, acc ->
+        %{acc | error: [err | acc.error]}
+    end)
+  end
+
+  defp display_error({error, [identifier, description, tags]}) do
+    Shell.error("""
+    Error creating #{identifier} with tags: #{inspect(tags)} and description: #{description} ¬
+      #{inspect(error)}
+    """)
+  end
+
+  defp display_malformed({line, line_num}, csv_path) do
+    Shell.info("""
+    #{IO.ANSI.yellow()} Malformed CSV line - #{inspect(line)}
+      (CSV) #{csv_path}:#{line_num}
+    #{IO.ANSI.default_color()}
+    """)
+  end
+
+  defp do_create_devices(acc, org, product, auth) do
+    tasks =
+      Enum.map(acc.data, fn [identifier, tags, description] ->
+        tags = split_tag_string(tags)
+
+        Task.async(fn ->
+          result =
+            NervesHubCLI.API.Device.create(org, product, identifier, description, tags, auth)
+
+          {result, [identifier, description, tags]}
+        end)
+      end)
+
+    %{acc | tasks: Task.yield_many(tasks, :infinity)}
+  end
+
+  defp filter_malformed(acc) do
+    Enum.with_index(acc.data)
+    |> Enum.reduce(%{acc | data: []}, fn
+      {[_identifier, _tags, _description] = line, _i}, acc ->
+        %{acc | data: [line | acc.data]}
+
+      {_line, _line_num} = bad_line, acc ->
+        %{acc | malformed: [bad_line | acc.malformed]}
+    end)
+  end
+end

--- a/lib/nerves_hub_cli/cli/ca_certificate.ex
+++ b/lib/nerves_hub_cli/cli/ca_certificate.ex
@@ -2,8 +2,6 @@ defmodule NervesHubCLI.CLI.CaCertificate do
   import NervesHubCLI.CLI.Utils
   alias NervesHubCLI.CLI.Shell
 
-  @shortdoc "Manages CA certificates"
-
   @moduledoc """
   Manages CA certificates for validating device connections
 

--- a/lib/nerves_hub_cli/cli/ca_certificate.ex
+++ b/lib/nerves_hub_cli/cli/ca_certificate.ex
@@ -1,0 +1,146 @@
+defmodule NervesHubCLI.CLI.CaCertificate do
+  import NervesHubCLI.CLI.Utils
+  alias NervesHubCLI.CLI.Shell
+
+  @shortdoc "Manages CA certificates"
+
+  @moduledoc """
+  Manages CA certificates for validating device connections
+
+  When a device connects for the first time to NervesHub, it
+  is possible to automatically register it if its certificate
+  has been signed by a trusted CA certificate. This set of
+  utilities helps manage the trusted CA certificates.
+
+  ## list
+
+      mix nerves_hub.ca_certificate list
+
+  ## register
+
+      mix nerves_hub.ca_certificate register CERT_PATH
+
+  ## unregister
+
+      mix nerves_hub.ca_certificate unregister CERT_SERIAL
+  """
+
+  @switches [
+    org: :string,
+    description: :string
+  ]
+
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
+    org = org(opts)
+
+    case args do
+      ["list"] ->
+        list(org)
+
+      ["register", certificate_path] ->
+        register(certificate_path, org, opts)
+
+      ["unregister", serial] ->
+        unregister(serial, org)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.ca_certificate`.
+
+    Usage:
+      mix nerves_hub.ca_certificate list
+      mix nerves_hub.ca_certificate register CERT_PATH
+      mix nerves_hub.ca_certificate unregister CERT_SERIAL
+
+    Run `mix help nerves_hub.ca_certificate` for more information.
+    """)
+  end
+
+  def list(org) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.CACertificate.list(org, auth) do
+      {:ok, %{"data" => ca_certificates}} ->
+        render_ca_certificates(ca_certificates)
+
+      error ->
+        Shell.info("Failed to list CA certificates \nreason: #{inspect(error)}")
+    end
+  end
+
+  def register(cert_path, org, opts \\ []) do
+    with {:ok, cert_pem} <- File.read(cert_path),
+         auth <- Shell.request_auth(),
+         description <- Keyword.get(opts, :description),
+         {:ok, %{"data" => %{"serial" => serial}}} <-
+           NervesHubCLI.API.CACertificate.create(org, cert_pem, auth, description) do
+      Shell.info("CA certificate '#{serial_as_hex(serial)}' registered.")
+    else
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def unregister(serial, org) do
+    if Shell.yes?("Unregister CA certificate '#{serial}'?") do
+      auth = Shell.request_auth()
+      Shell.info("Unregistering CA certificate '#{serial}'")
+
+      serial = if String.contains?(serial, ":"), do: serial_from_hex(serial), else: serial
+
+      case NervesHubCLI.API.CACertificate.delete(org, serial, auth) do
+        {:ok, ""} ->
+          Shell.info("CA certificate unregistered successfully")
+
+        error ->
+          Shell.render_error(error)
+      end
+    end
+  end
+
+  defp render_ca_certificates([]) do
+    Shell.info("No CA certificates have been registered on NervesHub.")
+  end
+
+  defp render_ca_certificates(ca_certificates) when is_list(ca_certificates) do
+    Shell.info("\nCA Certificates:")
+
+    Enum.each(ca_certificates, fn params ->
+      Shell.info("------------")
+
+      render_ca_certificate(params)
+      |> String.trim_trailing()
+      |> Shell.info()
+    end)
+
+    Shell.info("------------")
+    Shell.info("")
+  end
+
+  defp render_ca_certificate(params) do
+    {:ok, not_before, _} = DateTime.from_iso8601(params["not_before"])
+    {:ok, not_after, _} = DateTime.from_iso8601(params["not_after"])
+
+    """
+      serial:      #{params["serial"]}
+      serial hex:  #{serial_as_hex(params["serial"])}
+      validity:    #{DateTime.to_date(not_before)} - #{DateTime.to_date(not_after)} UTC
+      description: #{params["description"]}
+    """
+  end
+
+  defp serial_from_hex(hex) do
+    String.replace(hex, ":", "")
+    |> String.to_integer(16)
+    |> to_string()
+  end
+end

--- a/lib/nerves_hub_cli/cli/ca_certificate.ex
+++ b/lib/nerves_hub_cli/cli/ca_certificate.ex
@@ -12,15 +12,15 @@ defmodule NervesHubCLI.CLI.CaCertificate do
 
   ## list
 
-      mix nerves_hub.ca_certificate list
+      nerves_hub ca_certificate list
 
   ## register
 
-      mix nerves_hub.ca_certificate register CERT_PATH
+      nerves_hub ca_certificate register CERT_PATH
 
   ## unregister
 
-      mix nerves_hub.ca_certificate unregister CERT_SERIAL
+      nerves_hub ca_certificate unregister CERT_SERIAL
   """
 
   @switches [
@@ -52,14 +52,14 @@ defmodule NervesHubCLI.CLI.CaCertificate do
   @spec render_help() :: no_return()
   def render_help() do
     Shell.raise("""
-    Invalid arguments to `mix nerves_hub.ca_certificate`.
+    Invalid arguments to `nerves_hub ca_certificate`.
 
     Usage:
-      mix nerves_hub.ca_certificate list
-      mix nerves_hub.ca_certificate register CERT_PATH
-      mix nerves_hub.ca_certificate unregister CERT_SERIAL
+      nerves_hub ca_certificate list
+      nerves_hub ca_certificate register CERT_PATH
+      nerves_hub ca_certificate unregister CERT_SERIAL
 
-    Run `mix help nerves_hub.ca_certificate` for more information.
+    Run `nerves_hub help ca_certificate` for more information.
     """)
   end
 

--- a/lib/nerves_hub_cli/cli/config.ex
+++ b/lib/nerves_hub_cli/cli/config.ex
@@ -2,19 +2,20 @@ defmodule NervesHubCLI.CLI.Config do
   alias NervesHubCLI.CLI.Shell
 
   @switches []
-  @valid_config_keys ["uri"]
+  @valid_config_keys ["uri", "product", "org"]
 
   def run(args) do
     {_opts, args} = OptionParser.parse!(args, strict: @switches)
 
     case args do
       ["set", key, value] when key in @valid_config_keys ->
-        String.to_existing_atom(key)
+        # TODO: double check the usage of `String.to_atom/1` here. Should be safe since guarded
+        String.to_atom(key)
         |> NervesHubCLI.Config.put(value)
 
       ["get", key] when key in @valid_config_keys ->
         value =
-          String.to_existing_atom(key)
+          String.to_atom(key)
           |> NervesHubCLI.Config.get()
 
         Shell.info("#{key}: #{value}")

--- a/lib/nerves_hub_cli/cli/config.ex
+++ b/lib/nerves_hub_cli/cli/config.ex
@@ -1,0 +1,23 @@
+defmodule NervesHubCLI.CLI.Config do
+  alias NervesHubCLI.CLI.Shell
+
+  @switches []
+  @valid_config_keys ["uri"]
+
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    case args do
+      ["set", key, value] when key in @valid_config_keys ->
+        String.to_existing_atom(key)
+        |> NervesHubCLI.Config.put(value)
+
+      ["get", key] when key in @valid_config_keys ->
+        value =
+          String.to_existing_atom(key)
+          |> NervesHubCLI.Config.get()
+
+        Shell.info("#{key}: #{value}")
+    end
+  end
+end

--- a/lib/nerves_hub_cli/cli/config.ex
+++ b/lib/nerves_hub_cli/cli/config.ex
@@ -5,7 +5,7 @@ defmodule NervesHubCLI.CLI.Config do
   @valid_config_keys ["uri"]
 
   def run(args) do
-    {opts, args} = OptionParser.parse!(args, strict: @switches)
+    {_opts, args} = OptionParser.parse!(args, strict: @switches)
 
     case args do
       ["set", key, value] when key in @valid_config_keys ->

--- a/lib/nerves_hub_cli/cli/config.ex
+++ b/lib/nerves_hub_cli/cli/config.ex
@@ -13,12 +13,39 @@ defmodule NervesHubCLI.CLI.Config do
         String.to_atom(key)
         |> NervesHubCLI.Config.put(value)
 
+        Shell.info("Set config for #{key}")
+
       ["get", key] when key in @valid_config_keys ->
         value =
           String.to_atom(key)
           |> NervesHubCLI.Config.get()
 
         Shell.info("#{key}: #{value}")
+
+      ["clear", key] when key in @valid_config_keys ->
+        String.to_atom(key)
+        |> NervesHubCLI.Config.delete()
+
+        Shell.info("Cleared config for #{key}")
+
+      _ ->
+        render_help()
     end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `nerves_hub config`.
+
+    Usage:
+      nerves_hub config set KEY VALUE
+      nerves_hub device get KEY
+      nerves_hub config clear KEY
+
+    Valid keys are: #{Enum.join(@valid_config_keys, ", ")}
+
+    Run `nerves_hub help config` for more information.
+    """)
   end
 end

--- a/lib/nerves_hub_cli/cli/config.ex
+++ b/lib/nerves_hub_cli/cli/config.ex
@@ -9,7 +9,6 @@ defmodule NervesHubCLI.CLI.Config do
 
     case args do
       ["set", key, value] when key in @valid_config_keys ->
-        # TODO: double check the usage of `String.to_atom/1` here. Should be safe since guarded
         String.to_atom(key)
         |> NervesHubCLI.Config.put(value)
 

--- a/lib/nerves_hub_cli/cli/deployment.ex
+++ b/lib/nerves_hub_cli/cli/deployment.ex
@@ -1,0 +1,225 @@
+defmodule NervesHubCLI.CLI.Deployment do
+  @shortdoc "Manages NervesHub deployments"
+
+  @moduledoc """
+  Manage NervesHub deployments
+
+  ## list
+
+      mix nerves_hub.deployment list
+
+  ### Command-line options
+
+    * `--product` - (Optional) Only show deployments for one product.
+      This defaults to the Mix Project config `:app` name.
+
+  ## create
+
+  Create a new deployment
+
+      mix nerves_hub.deployment create
+
+  ### Command-line options
+
+    * `--name` - (Optional) The deployment name
+    * `--firmware` - (Optional) The firmware UUID
+    * `--version` - (Optional) Can be blank. The version requirement the device's
+      version must meet to qualify for the deployment
+    * `--tag` - (Optional) Multiple tags can be set by passing this key multiple
+      times
+
+  ## update
+
+  Update values on a deployment.
+
+  ### Examples
+
+  Update active firmware version
+
+      mix nerves_hub.deployment update dev firmware fd53d87c-99ca-5770-5540-edb5058ced5b
+
+  Activate / Deactivate a deployment
+
+      mix nerves_hub.deployment update dev state on
+
+  General usage:
+
+      mix nerves_hub.firmware update [deployment_name] [key] [value]
+
+  """
+
+  import NervesHubCLI.CLI.Utils
+
+  alias NervesHubCLI.CLI.Shell
+
+  @switches [
+    org: :string,
+    product: :string,
+    name: :string,
+    version: :string,
+    firmware: :string,
+    tag: :keep
+  ]
+
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
+    org = org(opts)
+    product = product(opts)
+
+    case args do
+      ["list"] ->
+        list(org, product)
+
+      ["create"] ->
+        create(org, product, opts)
+
+      ["update", deployment, key, value] ->
+        update(deployment, key, value, org, product)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.deployment`.
+
+    Usage:
+      mix nerves_hub.deployment list
+      mix nerves_hub.deployment create
+      mix nerves_hub.deployment update DEPLOYMENT_NAME KEY VALUE
+
+    Run `mix help nerves_hub.deployment` for more information.
+    """)
+  end
+
+  def list(org, product) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Deployment.list(org, product, auth) do
+      {:ok, %{"data" => []}} ->
+        Shell.info("No deployments have been created for product: #{product}")
+
+      {:ok, %{"data" => deployments}} ->
+        Shell.info("")
+        Shell.info("Deployments:")
+
+        Enum.each(deployments, fn params ->
+          Shell.info("------------")
+
+          render_deployment(params)
+          |> String.trim_trailing()
+          |> Shell.info()
+        end)
+
+        Shell.info("------------")
+        Shell.info("")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def create(org, product, opts) do
+    name = opts[:name] || Shell.prompt("Deployment name:")
+    firmware = opts[:firmware] || Shell.prompt("Firmware uuid:")
+    vsn = opts[:version] || Shell.prompt("Version condition:")
+
+    # Tags may be specified using multiple `--tag` options or as `--tag "a, b, c"`
+    tags = Keyword.get_values(opts, :tag) |> Enum.flat_map(&split_tag_string/1)
+
+    tags =
+      if tags == [] do
+        Shell.prompt("One or more comma-separated device tags:")
+        |> split_tag_string()
+      else
+        tags
+      end
+
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Deployment.create(org, product, name, firmware, vsn, tags, auth) do
+      {:ok, %{"data" => %{} = _deployment}} ->
+        Shell.info("""
+
+        Deployment #{name} created.
+
+        This deployment is not on by default. To turn it on, run:
+
+        mix nerves_hub.deployment update #{name} state on
+        """)
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def update(deployment, key, value, org, product, auth \\ nil) do
+    if key =~ ~r/is_active/i do
+      Shell.info("""
+
+      #{IO.ANSI.yellow()}warning: #{IO.ANSI.default_color()}Using #{IO.ANSI.yellow()}is_active#{IO.ANSI.default_color()} is deprecated. Please change your request to use #{IO.ANSI.cyan()}state#{IO.ANSI.default_color()} instead ¬
+
+      #{IO.ANSI.cyan()}  mix nerves_hub.deployment update #{deployment} state (on|off)#{IO.ANSI.default_color()}
+      """)
+    end
+
+    auth = auth || Shell.request_auth()
+
+    case NervesHubCLI.API.Deployment.update(
+           org,
+           product,
+           deployment,
+           Map.put(%{}, key, value),
+           auth
+         ) do
+      {:ok, %{"data" => deployment}} ->
+        Shell.info("")
+        Shell.info("Deployment updated:")
+
+        render_deployment(deployment)
+        |> String.trim_trailing()
+        |> Shell.info()
+
+        Shell.info("")
+
+      error ->
+        Shell.info("Failed to update deployment.\nReason: #{inspect(error)}")
+    end
+  end
+
+  defp render_deployment(params) do
+    """
+      name:      #{params["name"]}
+      state:     #{params["state"]}
+      firmware:  #{params["firmware_uuid"]}
+      #{render_conditions(params["conditions"])}
+    """
+  end
+
+  defp render_conditions(conditions) do
+    """
+    conditions:
+    """ <>
+      if Map.get(conditions, "version") != "" do
+        """
+            version: #{conditions["version"]}
+        """
+      else
+        ""
+      end <>
+      """
+          #{render_tags(conditions["tags"])}
+      """
+  end
+
+  defp render_tags(tags) do
+    """
+    device tags: [#{Enum.join(tags, ", ")}]
+    """
+  end
+end

--- a/lib/nerves_hub_cli/cli/deployment.ex
+++ b/lib/nerves_hub_cli/cli/deployment.ex
@@ -4,18 +4,19 @@ defmodule NervesHubCLI.CLI.Deployment do
 
   ## list
 
-      mix nerves_hub.deployment list
+      nerves_hub deployment list
 
   ### Command-line options
 
     * `--product` - (Optional) Only show deployments for one product.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
 
   ## create
 
   Create a new deployment
 
-      mix nerves_hub.deployment create
+      nerves_hub deployment create
 
   ### Command-line options
 
@@ -34,15 +35,15 @@ defmodule NervesHubCLI.CLI.Deployment do
 
   Update active firmware version
 
-      mix nerves_hub.deployment update dev firmware fd53d87c-99ca-5770-5540-edb5058ced5b
+      nerves_hub deployment update dev firmware fd53d87c-99ca-5770-5540-edb5058ced5b
 
   Activate / Deactivate a deployment
 
-      mix nerves_hub.deployment update dev state on
+      nerves_hub deployment update dev state on
 
   General usage:
 
-      mix nerves_hub.firmware update [deployment_name] [key] [value]
+      nerves_hub deployment update [deployment_name] [key] [value]
 
   """
 
@@ -84,14 +85,14 @@ defmodule NervesHubCLI.CLI.Deployment do
   @spec render_help() :: no_return()
   def render_help() do
     Shell.raise("""
-    Invalid arguments to `mix nerves_hub.deployment`.
+    Invalid arguments to `nerves_hub deployment`.
 
     Usage:
-      mix nerves_hub.deployment list
-      mix nerves_hub.deployment create
-      mix nerves_hub.deployment update DEPLOYMENT_NAME KEY VALUE
+      nerves_hub deployment list
+      nerves_hub deployment create
+      nerves_hub deployment update DEPLOYMENT_NAME KEY VALUE
 
-    Run `mix help nerves_hub.deployment` for more information.
+    Run `nerves_hub help deployment` for more information.
     """)
   end
 
@@ -148,7 +149,7 @@ defmodule NervesHubCLI.CLI.Deployment do
 
         This deployment is not on by default. To turn it on, run:
 
-        mix nerves_hub.deployment update #{name} state on
+        nerves_hub deployment update #{name} state on
         """)
 
       error ->
@@ -162,7 +163,7 @@ defmodule NervesHubCLI.CLI.Deployment do
 
       #{IO.ANSI.yellow()}warning: #{IO.ANSI.default_color()}Using #{IO.ANSI.yellow()}is_active#{IO.ANSI.default_color()} is deprecated. Please change your request to use #{IO.ANSI.cyan()}state#{IO.ANSI.default_color()} instead ¬
 
-      #{IO.ANSI.cyan()}  mix nerves_hub.deployment update #{deployment} state (on|off)#{IO.ANSI.default_color()}
+      #{IO.ANSI.cyan()}  nerves_hub deployment update #{deployment} state (on|off)#{IO.ANSI.default_color()}
       """)
     end
 

--- a/lib/nerves_hub_cli/cli/deployment.ex
+++ b/lib/nerves_hub_cli/cli/deployment.ex
@@ -1,6 +1,4 @@
 defmodule NervesHubCLI.CLI.Deployment do
-  @shortdoc "Manages NervesHub deployments"
-
   @moduledoc """
   Manage NervesHub deployments
 

--- a/lib/nerves_hub_cli/cli/device.ex
+++ b/lib/nerves_hub_cli/cli/device.ex
@@ -5,8 +5,6 @@ defmodule NervesHubCLI.CLI.Device do
 
   alias NimbleCSV.RFC4180, as: CSV
 
-  @shortdoc "Manages your NervesHub devices"
-
   @moduledoc """
   Manage your NervesHub devices.
 
@@ -397,6 +395,7 @@ defmodule NervesHubCLI.CLI.Device do
       |> Keyword.take([:firmware])
       |> OptionParser.to_argv()
 
+    # TODO: remove reference to mix task
     Mix.Task.run("burn", burn_args)
   end
 

--- a/lib/nerves_hub_cli/cli/device.ex
+++ b/lib/nerves_hub_cli/cli/device.ex
@@ -1,0 +1,570 @@
+defmodule NervesHubCLI.CLI.Device do
+  import NervesHubCLI.CLI.Utils
+
+  alias NervesHubCLI.CLI.{Shell, Bulk}
+
+  alias NimbleCSV.RFC4180, as: CSV
+
+  @shortdoc "Manages your NervesHub devices"
+
+  @moduledoc """
+  Manage your NervesHub devices.
+
+  ## create
+
+  Create a new NervesHub device. The shell will prompt for information about the
+  device. This information can be passed by specifying one or all of the command
+  line options.
+
+      mix nerves_hub.device create
+
+  ### Command-line options
+
+    * `--product` - (Optional) The product name.
+      This defaults to the Mix Project config `:app` name.
+    * `--identifier` - (Optional) The device identifier
+    * `--description` - (Optional) The description of the device
+    * `--tag` - (Optional) Multiple tags can be set by passing this key multiple
+      times
+
+  ## bulk_create
+
+  Create many NervesHub devices via a csv file.
+
+      mix nerves_hub.device bulk_create
+
+  The CSV file should be formated as:
+  ```csv
+  identifier,tags,description
+  ```
+
+  Where `tags` is a double-quoted string, containing comma delimited tags.
+
+  ### Example CSV file:
+
+  ```csv
+  identifier,tags,description
+  00000000d712d174,"tag1,tag2,tag3",some useful description of the device
+  00000000deadb33f,"qa,region1",this device should only be used with QA
+  ```
+
+  ### Command-line options
+
+    * `--csv` - Path to a CSV file
+
+    * `--product` - (Optional) The product name.
+      This defaults to the Mix Project config `:app` name.
+
+  ## update
+
+  Update values on a device.
+
+  ### Examples
+
+  List all devices
+
+      mix nerves_hub.device list
+
+  ### Command-line options
+
+  * `--product` - (Optional) The product name.
+      This defaults to the Mix Project config `:app` name.
+  * `--identifier` - (Optional) Only show device matching an identifier
+  * `--description` - (Optional) Only show devices matching a description
+  * `--tag` - (Optional) Only show devices matching tags. Multiple tags can be
+  supplied.
+  * `--status` - (Optional) Only show devices matching status
+  * `--version` - (Optional) Only show devices matching version
+
+
+  Update device tags
+
+      mix nerves_hub.device update 1234 tags dev qa
+
+  ## delete
+
+  Delete a device on NervesHub
+
+      mix nerves_hub.device delete DEVICE_IDENTIFIER
+
+  ## burn
+
+  Combine a firmware image with NervesHub provisioning information and burn the
+  result to an attached MicroSD card or file. This requires that the device
+  was already created. Calling burn without passing command-line options will
+  generate a new cert pair for the device. The command will end with calling
+  mix firmware.burn.
+
+      mix nerves_hub.device burn DEVICE_IDENTIFIER
+
+  ### Command-line options
+
+    * `--product` - (Optional) The product name.
+      This defaults to the Mix Project config `:app` name.
+    * `--cert` - (Optional) A path to an existing device certificate
+    * `--key` - (Optional) A path to an existing device private key
+    * `--path` - (Optional) The path to put the device certificates
+    * `--firmware` - (Optional) The path to the fw file to use. Defaults to
+      `<image_path>/<otp_app>.fw`
+
+  ## cert list
+
+  List all certificates for a device.
+
+      mix nerves_hub.device cert list DEVICE_IDENTIFIER
+
+  ### Command-line options
+
+    * `--product` - (Optional) The product name.
+      This defaults to the Mix Project config `:app` name.
+
+  ## cert create
+
+  Creates a new device certificate pair. The certificates will be placed in the
+  current working directory if no path is specified.
+
+      mix nerves_hub.device cert create DEVICE_IDENTIFIER
+
+  You must take on the role of the CA by providing your own signer certificate
+  and key and using the `--signer-cert` and `--signer-key` options.
+  These will be used with a NervesHub-defined certificate template to sign the
+  generated device certificate locally.
+
+  ### Command-line options
+
+    * `--product` - (Optional) The product name.
+      This defaults to the Mix Project config `:app` name.
+    * `--path` - (Optional) A local location for storing certificates
+    * `--signer-cert` - (required) Path to the signer certificate
+    * `--signer-key` - (required) Path to signer certificate's private key
+    * `--validity` - (Optional) Time in years a certificate should be valid. Defaults to 31.
+
+  ## cert import
+
+  Import a trusted certificate for authenticating a device.
+
+      mix nerves_hub.device cert import DEVICE_IDENTIFIER CERT_PATH
+
+  ### Command-line options
+
+    * `--product` - (Optional) The product name.
+      This defaults to the Mix Project config `:app` name.
+  """
+
+  @switches [
+    org: :string,
+    product: :string,
+    path: :string,
+    identifier: :string,
+    description: :string,
+    firmware: :string,
+    tag: :keep,
+    key: :string,
+    cert: :string,
+
+    # Options for local cert creation
+    signer_cert: :string,
+    signer_key: :string,
+    validity: :integer,
+
+    # device list filters
+    status: :string,
+    version: :string,
+
+    # device bulk_create
+    csv: :string
+  ]
+
+  @spec run([String.t()]) :: :ok | no_return()
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
+    org = org(opts)
+    product = product(opts)
+
+    case args do
+      ["list"] ->
+        list(org, product, opts)
+
+      ["create"] ->
+        create(org, product, opts)
+
+      ["bulk_create"] ->
+        bulk_create(org, product, opts)
+
+      ["delete", identifier] ->
+        delete(org, product, identifier)
+
+      ["burn", identifier] ->
+        burn(identifier, opts)
+
+      ["cert", "list", device] ->
+        cert_list(org, product, device)
+
+      ["cert", "create", device] ->
+        cert_create(org, device, opts)
+
+      ["cert", "import", device, cert_path] ->
+        cert_import(org, product, device, cert_path, opts)
+
+      ["update", identifier | update_data] ->
+        update(org, product, identifier, update_data)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.device`.
+
+    Usage:
+      mix nerves_hub.device list
+      mix nerves_hub.device create
+      mix nerves_hub.device update KEY VALUE
+      mix nerves_hub.device delete DEVICE_IDENTIFIER
+      mix nerves_hub.device burn DEVICE_IDENTIFIER
+      mix nerves_hub.device cert list DEVICE_IDENTIFIER
+      mix nerves_hub.device cert create DEVICE_IDENTIFIER
+      mix nerves_hub.device cert import DEVICE_IDENTIFIER CERT_PATH
+
+    Run `mix help nerves_hub.device` for more information.
+    """)
+  end
+
+  @spec list(String.t(), String.t(), keyword()) :: :ok
+  def list(org, product, opts) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Device.list(org, product, auth) do
+      {:ok, %{"data" => devices}} ->
+        filetered_devices = Enum.filter(devices, &filter_devices(&1, opts))
+        Shell.info(render_devices(org, product, filetered_devices))
+        Shell.info("Total devices displayed: #{Enum.count(filetered_devices)}")
+        Shell.info("Total devices: #{Enum.count(devices)}")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  @spec create(String.t(), String.t(), keyword()) :: :ok
+  def create(org, product, opts) do
+    identifier = opts[:identifier] || Shell.prompt("Identifier (e.g., serial number):")
+    description = opts[:description] || Shell.prompt("Description:")
+
+    # Tags may be specified using multiple `--tag` options or as `--tag "a, b, c"`
+    tags = Keyword.get_values(opts, :tag) |> Enum.flat_map(&split_tag_string/1)
+
+    tags =
+      if tags == [] do
+        Shell.prompt("One or more comma-separated tags:")
+        |> split_tag_string()
+      else
+        tags
+      end
+
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Device.create(org, product, identifier, description, tags, auth) do
+      {:ok, %{"data" => %{} = _device}} ->
+        Shell.info("""
+        Device #{identifier} created.
+
+        If your device has an ATECCx08A module or NervesKey that has been
+        provisioned by a CA/signer certificate known to NervesHub, it is
+        ready to go.
+
+        If not using a hardware module to protect the device's private
+        key, create and register a certificate and key pair manually by
+        running:
+
+          mix nerves_hub.device cert create #{identifier} --signer-key key.pem --signer-cert cert.pem
+        """)
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  @spec bulk_create(String.t(), String.t(), keyword()) :: :ok
+  def bulk_create(org, product, args) do
+    auth = Shell.request_auth()
+    path = args[:csv]
+
+    unless is_bitstring(path) do
+      Shell.render_error({:error, "--csv is required for bulk_create"})
+    end
+
+    unless File.exists?(path) do
+      Shell.render_error({:error, "CSV file not found"})
+    end
+
+    File.stream!(path)
+    |> CSV.parse_stream()
+    |> Enum.to_list()
+    |> Bulk.create_devices(org, product, auth)
+    |> Bulk.display_results(path)
+  end
+
+  @spec update(String.t(), String.t(), String.t(), [String.t()]) :: :ok
+  def update(org, product, identifier, ["tags" | tags]) do
+    # Split up tags with comma separators
+    tags = Enum.flat_map(tags, &split_tag_string/1)
+
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Device.update(org, product, identifier, %{tags: tags}, auth) do
+      {:ok, %{"data" => %{} = _device}} ->
+        Shell.info("Device #{identifier} updated")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def update(org, product, identifier, [key, value]) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Device.update(org, product, identifier, %{key => value}, auth) do
+      {:ok, %{"data" => %{} = _device}} ->
+        Shell.info("Device #{identifier} updated")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def update(_org, _product, _identifier, data) do
+    Shell.render_error("Unable to update data: #{inspect(data)}")
+  end
+
+  @spec delete(String.t(), String.t(), String.t()) :: :ok
+  def delete(org, product, identifier) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Device.delete(org, product, identifier, auth) do
+      {:ok, _} ->
+        Shell.info("Device #{identifier} deleted")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  @spec burn(String.t(), keyword()) :: :ok
+  def burn(identifier, opts) do
+    path = opts[:path] || NervesHubCLI.home_dir()
+    cert_path = opts[:cert]
+    key_path = opts[:key]
+
+    {cert_path, key_path} =
+      if key_path == nil and cert_path == nil do
+        cert_path = Path.join(path, identifier <> "-cert.pem")
+        key_path = Path.join(path, identifier <> "-key.pem")
+
+        unless File.exists?(key_path) and File.exists?(cert_path) do
+          Shell.raise("""
+            A private key and certificate for #{identifier}
+            does not exists at path #{path}.
+
+            To generate certificates for #{identifier}
+
+              mix nerves_hub.device cert create #{identifier}
+
+          """)
+        end
+
+        {cert_path, key_path}
+      else
+        if key_path == nil or cert_path == nil do
+          Shell.raise("Must specify both --key and --cert")
+        end
+
+        {cert_path, key_path}
+      end
+
+    Shell.info("Burning firmware")
+    System.put_env("NERVES_SERIAL_NUMBER", identifier)
+    System.put_env("NERVES_HUB_CERT", File.read!(cert_path))
+    System.put_env("NERVES_HUB_KEY", File.read!(key_path))
+
+    burn_args =
+      opts
+      |> Keyword.take([:firmware])
+      |> OptionParser.to_argv()
+
+    Mix.Task.run("burn", burn_args)
+  end
+
+  @spec cert_list(String.t(), String.t(), String.t()) :: :ok
+  def cert_list(org, product, identifier) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.DeviceCertificate.list(org, product, identifier, auth) do
+      {:ok, %{"data" => certs}} ->
+        render_certs(identifier, certs)
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  @spec cert_create(
+          String.t(),
+          String.t(),
+          keyword()
+        ) :: :ok
+  def cert_create(org, identifier, opts) do
+    Shell.info("Creating certificate for #{identifier}")
+    path = opts[:path] || NervesHubCLI.home_dir()
+    File.mkdir_p!(path)
+
+    key = X509.PrivateKey.new_ec(:secp256r1)
+    pem_key = X509.PrivateKey.to_pem(key)
+
+    csr = X509.CSR.new(key, "/O=#{org}/CN=#{identifier}")
+
+    with {:ok, cert} <- do_cert_create(csr, opts),
+         :ok <- File.write(Path.join(path, "#{identifier}-cert.pem"), cert),
+         :ok <- File.write(Path.join(path, "#{identifier}-key.pem"), pem_key) do
+      Shell.info("Finished")
+      :ok
+    else
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  @spec cert_import(
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          keyword()
+        ) :: :ok
+  def cert_import(org, product, identifier, cert_path, _opts) do
+    Shell.info("Importing certificate for #{identifier}")
+
+    with {:ok, cert_pem} <- File.read(cert_path),
+         auth <- Shell.request_auth(),
+         {:ok, %{"data" => %{"serial" => serial}}} <-
+           NervesHubCLI.API.DeviceCertificate.create(org, product, identifier, cert_pem, auth) do
+      Shell.info("Device certificate '#{serial_as_hex(serial)}' registered.")
+    else
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  defp render_certs(identifier, certs) when is_list(certs) do
+    Shell.info("\nDevice: #{identifier}")
+    Shell.info("Certificates:")
+
+    Enum.each(certs, fn params ->
+      Shell.info("------------")
+
+      render_cert(identifier, params)
+      |> String.trim_trailing()
+      |> Shell.info()
+    end)
+
+    Shell.info("------------")
+    Shell.info("")
+  end
+
+  defp render_cert(_identifier, params) do
+    {:ok, not_before, _} = DateTime.from_iso8601(params["not_before"])
+
+    {:ok, not_after, _} = DateTime.from_iso8601(params["not_after"])
+
+    """
+      serial:     #{params["serial"]}
+      serial hex: #{serial_as_hex(params["serial"])}
+      validity:   #{DateTime.to_date(not_before)} - #{DateTime.to_date(not_after)} UTC
+    """
+  end
+
+  defp render_devices(_org, _product, []), do: ""
+
+  defp render_devices(org, product, devices) do
+    title = "Devices for #{org} / #{product}"
+
+    header = [
+      "Identifier",
+      "Tags",
+      "Version",
+      "Firmware UUID",
+      "Status",
+      "Last connected",
+      "Description"
+    ]
+
+    rows =
+      Enum.map(devices, fn device ->
+        [
+          device["identifier"],
+          Enum.join(device["tags"] || [], ", "),
+          device["version"],
+          device["firmware_metadata"]["uuid"],
+          device["status"],
+          device["last_communication"],
+          device["description"]
+        ]
+      end)
+
+    TableRex.quick_render!(rows, header, title)
+  end
+
+  defp filter_devices(device, [{:status, val} | rest]) do
+    if device["status"] == val, do: filter_devices(device, rest)
+  end
+
+  defp filter_devices(device, [{:version, version} | rest]) do
+    if device["version"] == version, do: filter_devices(device, rest)
+  end
+
+  defp filter_devices(device, [{:tag, tag} | rest]) do
+    tags = device["tags"] || []
+
+    if Enum.any?(tags, fn device_tag -> device_tag == tag end),
+      do: filter_devices(device, rest)
+  end
+
+  defp filter_devices(device, [{:identifier, identifier} | rest]) do
+    if device["identifier"] == identifier, do: filter_devices(device, rest)
+  end
+
+  defp filter_devices(device, [{:description, description} | rest]) do
+    if device["description"] == description, do: filter_devices(device, rest)
+  end
+
+  defp filter_devices(device, [_ | rest]) do
+    filter_devices(device, rest)
+  end
+
+  defp filter_devices(device, []), do: device
+
+  defp do_cert_create(csr, opts) do
+    Shell.info("Signer cert path: #{opts[:signer_cert]}")
+    Shell.info("Signer key path: #{opts[:signer_key]}")
+
+    with {:ok, signer_cert_pem} <- File.read(opts[:signer_cert]),
+         {:ok, signer_key_pem} <- File.read(opts[:signer_key]),
+         {:ok, signer_cert} <- X509.Certificate.from_pem(signer_cert_pem),
+         {:ok, signer_key} <- X509.PrivateKey.from_pem(signer_key_pem) do
+      subject_rdn = X509.CSR.subject(csr) |> X509.RDNSequence.to_string()
+      public_key = X509.CSR.public_key(csr)
+
+      cert =
+        X509.Certificate.new(public_key, subject_rdn, signer_cert, signer_key,
+          template: NervesHubCLI.Certificate.device_template(opts[:validity])
+        )
+
+      {:ok, X509.Certificate.to_pem(cert)}
+    end
+  end
+end

--- a/lib/nerves_hub_cli/cli/device.ex
+++ b/lib/nerves_hub_cli/cli/device.ex
@@ -402,8 +402,7 @@ defmodule NervesHubCLI.CLI.Device do
       |> Keyword.take([:firmware])
       |> OptionParser.to_argv()
 
-    # TODO: remove reference to mix task
-    Mix.Task.run("burn", burn_args)
+    System.cmd("mix", ["burn" | burn_args])
   end
 
   @spec cert_list(String.t(), String.t(), String.t()) :: :ok

--- a/lib/nerves_hub_cli/cli/device.ex
+++ b/lib/nerves_hub_cli/cli/device.ex
@@ -14,12 +14,13 @@ defmodule NervesHubCLI.CLI.Device do
   device. This information can be passed by specifying one or all of the command
   line options.
 
-      mix nerves_hub.device create
+      nerves_hub device create
 
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
     * `--identifier` - (Optional) The device identifier
     * `--description` - (Optional) The description of the device
     * `--tag` - (Optional) Multiple tags can be set by passing this key multiple
@@ -29,7 +30,7 @@ defmodule NervesHubCLI.CLI.Device do
 
   Create many NervesHub devices via a csv file.
 
-      mix nerves_hub.device bulk_create
+      nerves_hub device bulk_create
 
   The CSV file should be formated as:
   ```csv
@@ -51,7 +52,8 @@ defmodule NervesHubCLI.CLI.Device do
     * `--csv` - Path to a CSV file
 
     * `--product` - (Optional) The product name.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
 
   ## update
 
@@ -61,12 +63,13 @@ defmodule NervesHubCLI.CLI.Device do
 
   List all devices
 
-      mix nerves_hub.device list
+      nerves_hub device list
 
   ### Command-line options
 
   * `--product` - (Optional) The product name.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
   * `--identifier` - (Optional) Only show device matching an identifier
   * `--description` - (Optional) Only show devices matching a description
   * `--tag` - (Optional) Only show devices matching tags. Multiple tags can be
@@ -77,13 +80,13 @@ defmodule NervesHubCLI.CLI.Device do
 
   Update device tags
 
-      mix nerves_hub.device update 1234 tags dev qa
+      nerves_hub device update 1234 tags dev qa
 
   ## delete
 
   Delete a device on NervesHub
 
-      mix nerves_hub.device delete DEVICE_IDENTIFIER
+      nerves_hub device delete DEVICE_IDENTIFIER
 
   ## burn
 
@@ -93,12 +96,13 @@ defmodule NervesHubCLI.CLI.Device do
   generate a new cert pair for the device. The command will end with calling
   mix firmware.burn.
 
-      mix nerves_hub.device burn DEVICE_IDENTIFIER
+      nerves_hub device burn DEVICE_IDENTIFIER
 
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
     * `--cert` - (Optional) A path to an existing device certificate
     * `--key` - (Optional) A path to an existing device private key
     * `--path` - (Optional) The path to put the device certificates
@@ -109,19 +113,20 @@ defmodule NervesHubCLI.CLI.Device do
 
   List all certificates for a device.
 
-      mix nerves_hub.device cert list DEVICE_IDENTIFIER
+      nerves_hub device cert list DEVICE_IDENTIFIER
 
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
 
   ## cert create
 
   Creates a new device certificate pair. The certificates will be placed in the
   current working directory if no path is specified.
 
-      mix nerves_hub.device cert create DEVICE_IDENTIFIER
+      nerves_hub device cert create DEVICE_IDENTIFIER
 
   You must take on the role of the CA by providing your own signer certificate
   and key and using the `--signer-cert` and `--signer-key` options.
@@ -131,7 +136,8 @@ defmodule NervesHubCLI.CLI.Device do
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
     * `--path` - (Optional) A local location for storing certificates
     * `--signer-cert` - (required) Path to the signer certificate
     * `--signer-key` - (required) Path to signer certificate's private key
@@ -141,12 +147,13 @@ defmodule NervesHubCLI.CLI.Device do
 
   Import a trusted certificate for authenticating a device.
 
-      mix nerves_hub.device cert import DEVICE_IDENTIFIER CERT_PATH
+      nerves_hub device cert import DEVICE_IDENTIFIER CERT_PATH
 
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
   """
 
   @switches [
@@ -217,19 +224,19 @@ defmodule NervesHubCLI.CLI.Device do
   @spec render_help() :: no_return()
   def render_help() do
     Shell.raise("""
-    Invalid arguments to `mix nerves_hub.device`.
+    Invalid arguments to `nerves_hub device`.
 
     Usage:
-      mix nerves_hub.device list
-      mix nerves_hub.device create
-      mix nerves_hub.device update KEY VALUE
-      mix nerves_hub.device delete DEVICE_IDENTIFIER
-      mix nerves_hub.device burn DEVICE_IDENTIFIER
-      mix nerves_hub.device cert list DEVICE_IDENTIFIER
-      mix nerves_hub.device cert create DEVICE_IDENTIFIER
-      mix nerves_hub.device cert import DEVICE_IDENTIFIER CERT_PATH
+      nerves_hub device list
+      nerves_hub device create
+      nerves_hub device update KEY VALUE
+      nerves_hub device delete DEVICE_IDENTIFIER
+      nerves_hub device burn DEVICE_IDENTIFIER
+      nerves_hub device cert list DEVICE_IDENTIFIER
+      nerves_hub device cert create DEVICE_IDENTIFIER
+      nerves_hub device cert import DEVICE_IDENTIFIER CERT_PATH
 
-    Run `mix help nerves_hub.device` for more information.
+    Run `nerves_hub help device` for more information.
     """)
   end
 
@@ -280,7 +287,7 @@ defmodule NervesHubCLI.CLI.Device do
         key, create and register a certificate and key pair manually by
         running:
 
-          mix nerves_hub.device cert create #{identifier} --signer-key key.pem --signer-cert cert.pem
+          nerves_hub device cert create #{identifier} --signer-key key.pem --signer-cert cert.pem
         """)
 
       error ->
@@ -371,7 +378,7 @@ defmodule NervesHubCLI.CLI.Device do
 
             To generate certificates for #{identifier}
 
-              mix nerves_hub.device cert create #{identifier}
+              nerves_hub device cert create #{identifier}
 
           """)
         end

--- a/lib/nerves_hub_cli/cli/firmware.ex
+++ b/lib/nerves_hub_cli/cli/firmware.ex
@@ -1,5 +1,4 @@
 defmodule NervesHubCLI.CLI.Firmware do
-
   @moduledoc """
   Manage Firmware on NervesHub
 
@@ -9,12 +8,14 @@ defmodule NervesHubCLI.CLI.Firmware do
   is optional. If it is not specified, NervesHub will locate the firmware
   based off the project settings.
 
-      mix nerves_hub.firmware publish [Optional: /path/to/app.firmware]
+      nerves_hub firmware publish [Optional: /path/to/app.firmware]
 
   ### Command-line options
 
     * `--product` - (Optional) The product name to publish the firmware to.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
+
     * `--deploy` - (Optional) The name of a deployment to update following
       firmware publish. This key can be passed multiple times to update
       multiple deployments.
@@ -23,19 +24,21 @@ defmodule NervesHubCLI.CLI.Firmware do
 
   ## list
 
-      mix nerves_hub.firmware list
+      nerves_hub firmware list
 
   ### Command-line options
 
     * `--product` - (Optional) The product name to publish the firmware to.
-      This defaults to the Mix Project config `:app` name.
+      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      the global configuration via `nerves_hub config set product "product_name"`
+
 
   ## delete
 
   Firmware can only be deleted if it is not associated to any deployment.
   Call `list` to retrieve firmware UUIDs
 
-      mix nerves_hub.firmware delete [firmware_uuid]
+      nerves_hub firmware delete [firmware_uuid]
 
   ## sign
 
@@ -43,7 +46,7 @@ defmodule NervesHubCLI.CLI.Firmware do
   is optional. If it is not specified, NervesHub will locate the firmware
   based off the project settings.
 
-      mix nerves_hub.firmware sign [Optional: /path/to/app.firmware]
+      nerves_hub firmware sign [Optional: /path/to/app.firmware]
 
   ### Command-line options
 
@@ -104,12 +107,12 @@ defmodule NervesHubCLI.CLI.Firmware do
     Invalid arguments
 
     Usage:
-      mix nerves_hub.firmware list
-      mix nerves_hub.firmware publish
-      mix nerves_hub.firmware delete
-      mix nerves_hub.firmware sign
+      nerves_hub firmware list
+      nerves_hub firmware publish
+      nerves_hub firmware delete
+      nerves_hub firmware sign
 
-    Run `mix help nerves_hub.firmware` for more information.
+    Run `nerves_hub help firmware` for more information.
     """)
   end
 

--- a/lib/nerves_hub_cli/cli/firmware.ex
+++ b/lib/nerves_hub_cli/cli/firmware.ex
@@ -237,7 +237,7 @@ defmodule NervesHubCLI.CLI.Firmware do
     Enum.each(deployments, fn deployment_name ->
       Shell.info("Deploying firmware to #{deployment_name}")
 
-      Mix.Tasks.NervesHub.Deployment.update(
+      NervesHubCLI.CLI.Deployment.update(
         deployment_name,
         "firmware",
         firmware["uuid"],

--- a/lib/nerves_hub_cli/cli/firmware.ex
+++ b/lib/nerves_hub_cli/cli/firmware.ex
@@ -77,10 +77,6 @@ defmodule NervesHubCLI.CLI.Firmware do
       ["list"] ->
         list(org, product)
 
-      ["publish" | []] ->
-        firmware()
-        |> publish_confirm(org, opts)
-
       ["publish", firmware] when is_binary(firmware) ->
         firmware
         |> Path.expand()
@@ -88,10 +84,6 @@ defmodule NervesHubCLI.CLI.Firmware do
 
       ["delete", uuid] when is_binary(uuid) ->
         delete_confirm(uuid, org, product)
-
-      ["sign"] ->
-        firmware()
-        |> sign(org, opts)
 
       ["sign", firmware] ->
         sign(firmware, org, opts)

--- a/lib/nerves_hub_cli/cli/firmware.ex
+++ b/lib/nerves_hub_cli/cli/firmware.ex
@@ -1,0 +1,260 @@
+defmodule NervesHubCLI.CLI.Firmware do
+  @shortdoc "Manages firmware on NervesHub"
+
+  @moduledoc """
+  Manage Firmware on NervesHub
+
+  ## publish
+
+  Upload signed firmware to NervesHub. Supplying a path to the firmware file
+  is optional. If it is not specified, NervesHub will locate the firmware
+  based off the project settings.
+
+      mix nerves_hub.firmware publish [Optional: /path/to/app.firmware]
+
+  ### Command-line options
+
+    * `--product` - (Optional) The product name to publish the firmware to.
+      This defaults to the Mix Project config `:app` name.
+    * `--deploy` - (Optional) The name of a deployment to update following
+      firmware publish. This key can be passed multiple times to update
+      multiple deployments.
+    * `--key` - (Optional) The firmware signing key to sign the firmware with.
+    * `--ttl` - (Optional) The firmware max time to live seconds.
+
+  ## list
+
+      mix nerves_hub.firmware list
+
+  ### Command-line options
+
+    * `--product` - (Optional) The product name to publish the firmware to.
+      This defaults to the Mix Project config `:app` name.
+
+  ## delete
+
+  Firmware can only be deleted if it is not associated to any deployment.
+  Call `list` to retrieve firmware UUIDs
+
+      mix nerves_hub.firmware delete [firmware_uuid]
+
+  ## sign
+
+  Sign the local firmware. Supplying a path to the firmware file
+  is optional. If it is not specified, NervesHub will locate the firmware
+  based off the project settings.
+
+      mix nerves_hub.firmware sign [Optional: /path/to/app.firmware]
+
+  ### Command-line options
+
+    * `--key` - (Optional) The firmware signing key to sign the firmware with.
+
+  """
+
+  import NervesHubCLI.CLI.Utils
+  alias NervesHubCLI.Cmd
+  alias NervesHubCLI.CLI.Shell
+
+  @switches [
+    org: :string,
+    product: :string,
+    deploy: :keep,
+    key: :string,
+    ttl: :integer
+  ]
+
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
+    org = org(opts)
+    product = product(opts)
+
+    case args do
+      ["list"] ->
+        list(org, product)
+
+      ["publish" | []] ->
+        firmware()
+        |> publish_confirm(org, opts)
+
+      ["publish", firmware] when is_binary(firmware) ->
+        firmware
+        |> Path.expand()
+        |> publish_confirm(org, opts)
+
+      ["delete", uuid] when is_binary(uuid) ->
+        delete_confirm(uuid, org, product)
+
+      ["sign"] ->
+        firmware()
+        |> sign(org, opts)
+
+      ["sign", firmware] ->
+        sign(firmware, org, opts)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments
+
+    Usage:
+      mix nerves_hub.firmware list
+      mix nerves_hub.firmware publish
+      mix nerves_hub.firmware delete
+      mix nerves_hub.firmware sign
+
+    Run `mix help nerves_hub.firmware` for more information.
+    """)
+  end
+
+  def list(org, product) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Firmware.list(org, product, auth) do
+      {:ok, %{"data" => []}} ->
+        Shell.info("No firmware has been published for product: #{product}")
+
+      {:ok, %{"data" => firmwares}} ->
+        Shell.info("")
+        Shell.info("Firmwares:")
+
+        Enum.each(firmwares, fn metadata ->
+          Shell.info("------------")
+
+          render_firmware(metadata)
+          |> String.trim_trailing()
+          |> Shell.info()
+        end)
+
+        Shell.info("")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  defp publish_confirm(firmware, org, opts) do
+    with true <- File.exists?(firmware),
+         {:ok, metadata} <- metadata(firmware) do
+      Shell.info("------------")
+      Shell.info("Organization: #{org}")
+
+      render_firmware(metadata)
+      |> String.trim_trailing()
+      |> Shell.info()
+
+      if Shell.yes?("Publish Firmware?") do
+        product = metadata["product"]
+        publish(firmware, org, product, opts)
+      end
+    else
+      false ->
+        Shell.info("Cannot find firmware at #{firmware}")
+
+      {:error, reason} ->
+        Shell.info("Unable to parse firmware metadata: #{inspect(reason)}")
+    end
+  end
+
+  defp delete_confirm(uuid, org, product) do
+    Shell.info("UUID: #{uuid}")
+
+    if Shell.yes?("Delete Firmware?") do
+      delete(uuid, org, product)
+    end
+  end
+
+  defp publish(firmware, org, product, opts) do
+    if opts[:key] do
+      sign(firmware, org, opts)
+    end
+
+    auth = Shell.request_auth()
+
+    ttl = opts[:ttl]
+
+    case NervesHubCLI.API.Firmware.create(org, product, firmware, ttl, auth) do
+      {:ok, %{"data" => %{} = firmware}} ->
+        Shell.info("\nFirmware published successfully")
+
+        Keyword.get_values(opts, :deploy)
+        |> maybe_deploy(firmware, org, product, auth)
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  defp delete(uuid, org, product) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Firmware.delete(org, product, uuid, auth) do
+      {:ok, ""} ->
+        Shell.info("Firmware deleted successfully")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def sign(firmware, org, opts) do
+    key = opts[:key] || Shell.raise("Must specify key with --key")
+    Shell.info("Signing #{firmware}")
+    Shell.info("With key #{key}")
+
+    with {:ok, public_key, private_key} <- Shell.request_keys(org, key),
+         :ok <-
+           Cmd.fwup(
+             [
+               "--sign",
+               "-i",
+               firmware,
+               "-o",
+               firmware,
+               "--private-key",
+               private_key,
+               "--public-key",
+               public_key
+             ],
+             File.cwd!()
+           ) do
+      Shell.info("Finished signing")
+    else
+      error -> Shell.render_error(error)
+    end
+  end
+
+  defp maybe_deploy([], _, _, _, _), do: :ok
+
+  defp maybe_deploy(deployments, firmware, org, product, auth) do
+    Enum.each(deployments, fn deployment_name ->
+      Shell.info("Deploying firmware to #{deployment_name}")
+
+      Mix.Tasks.NervesHub.Deployment.update(
+        deployment_name,
+        "firmware",
+        firmware["uuid"],
+        org,
+        product,
+        auth
+      )
+    end)
+  end
+
+  defp render_firmware(params) do
+    """
+      product:      #{params["product"]}
+      version:      #{params["version"]}
+      platform:     #{params["platform"]}
+      architecture: #{params["architecture"]}
+      uuid:         #{params["uuid"]}
+    """
+  end
+end

--- a/lib/nerves_hub_cli/cli/firmware.ex
+++ b/lib/nerves_hub_cli/cli/firmware.ex
@@ -1,5 +1,4 @@
 defmodule NervesHubCLI.CLI.Firmware do
-  @shortdoc "Manages firmware on NervesHub"
 
   @moduledoc """
   Manage Firmware on NervesHub

--- a/lib/nerves_hub_cli/cli/key.ex
+++ b/lib/nerves_hub_cli/cli/key.ex
@@ -1,0 +1,319 @@
+defmodule NervesHubCLI.CLI.Key do
+  import NervesHubCLI.CLI.Utils
+
+  alias NervesHubCLI.CLI.Shell
+
+  @shortdoc "Manages firmware signing keys"
+
+  @moduledoc """
+  Manages firmware signing keys
+
+  Firmware signing keys consist of public and private keys. The `mix
+  nerves_hub.key` task manages both pieces for you. Private signing keys are
+  password-protected and are NEVER sent to NervesHub or any other server.
+  Public keys, however, are registered with NervesHub and embedded in your
+  firmware.
+
+  Signing keys are stored in `~/.nerves-hub/keys`. Keys may be shared between
+  developers by copying the files in this folder.
+
+  NervesHub can manage more than one key so that you can have different
+  development and production keys in use. For example, production devices
+  deployed with only the production public key will not accept firmware signed
+  by development keys.
+
+  To ensure that firmware includes keys registered with NervesHub, add the
+  following entry in your project's `config.exs`:
+
+      # List the public firmware signing keys to include on the device
+      config :nerves_hub,
+        public_keys: [:my_dev_key, :my_prod_key]
+
+  ## list
+
+  List the keys known to NervesHub
+
+      mix nerves_hub.key list
+
+  ### Command-line options
+
+    * `--local` - (Optional) Do not request key information from NervesHub
+
+  ## create
+
+  Create a new firmware signing key pair with the specified name and register
+  the public key with NervesHub
+
+      mix nerves_hub.key create NAME
+
+  ### Command-line options
+
+    * `--local` - (Optional) Do not register the public key with NervesHub
+
+  ## delete
+
+  Delete a signing key locally and on NervesHub
+
+      mix nerves_hub.key delete NAME
+
+  ### Command-line options
+
+    * `--local` - (Optional) Perform the operation only locally defaults to
+      `false` which will perform both local and remote operations
+
+  ## import
+
+  Import an existing key locally and on NervesHub
+
+      mix nerves_hub.key import NAME PUBLIC_KEY_FILE PRIVATE_KEY_FILE
+
+  ### Command-line options
+
+    * `--local` - (Optional) Do not register the public key with NervesHub
+
+  ## export
+
+  Export a signing key to a tar.gz archive.
+
+      mix nerves_hub.key export NAME
+
+  ### Command-line options
+
+    * `--path` - (Optional) A local location for exporting keys.
+  """
+
+  @switches [
+    org: :string,
+    path: :string,
+    local: :boolean
+  ]
+
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
+    org = org(opts)
+
+    case args do
+      ["list"] ->
+        list(org, opts)
+
+      ["create", name] ->
+        create(name, org, opts)
+
+      ["delete", name] ->
+        delete(name, org, opts)
+
+      ["import", name, public_key_file, private_key_file] ->
+        import(name, org, public_key_file, private_key_file, opts)
+
+      ["export", name] ->
+        export(name, org, opts)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.key`.
+
+    Usage:
+      mix nerves_hub.key list
+      mix nerves_hub.key create NAME
+      mix nerves_hub.key delete NAME
+      mix nerves_hub.key import NAME PUBLIC_KEY_FILE PRIVATE_KEY_FILE
+      mix nerves_hub.key export NAME
+
+    Run `mix help nerves_hub.key` for more information.
+    """)
+  end
+
+  def list(org, opts) do
+    if Keyword.get(opts, :local, false) do
+      list_local(org)
+    else
+      list_remote(org)
+    end
+  end
+
+  def list_local(org) do
+    NervesHubCLI.Key.local_keys(org)
+    |> Enum.map(&stringify/1)
+    |> render_keys()
+  end
+
+  def list_remote(org) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Key.list(org, auth) do
+      {:ok, %{"data" => keys}} ->
+        render_keys(keys)
+
+      error ->
+        Shell.info("Failed to list signing keys \nreason: #{inspect(error)}")
+    end
+  end
+
+  def create(name, org, opts) do
+    if NervesHubCLI.Key.exists?(org, name) do
+      Shell.raise("""
+      The key '#{name}' already exists.
+
+      Please choose a different name or delete by
+      running `mix nerves_hub.key delete #{name} [--local]`
+      """)
+    else
+      if Keyword.get(opts, :local, false) do
+        with {:ok, key} <- create_local(name, org) do
+          Shell.info("\nSuccess. Key information:")
+          render_key(%{"name" => name, "key" => key})
+        else
+          error ->
+            Shell.render_error(error)
+        end
+      else
+        with {:ok, key} <- create_local(name, org),
+             {:ok, %{"data" => key}} <- create_remote(name, key, org) do
+          Shell.info("\nSuccess. Key information:")
+          render_key(key)
+        else
+          error ->
+            Shell.render_error(error)
+        end
+      end
+    end
+  end
+
+  def delete(name, org, opts) do
+    if Shell.yes?("Delete signing key '#{name}'?") do
+      if Keyword.get(opts, :local, false) do
+        delete_local(name, org)
+      else
+        with {:ok, ""} <- delete_remote(name, org),
+             :ok <- delete_local(name, org) do
+          :ok
+        else
+          error ->
+            Shell.render_error(error)
+        end
+      end
+    end
+  end
+
+  def import(name, org, public_key_file, private_key_file, opts) do
+    if NervesHubCLI.Key.exists?(org, name) do
+      Shell.raise("The key #{name} already exists, aborting")
+    else
+      if Keyword.get(opts, :local, false) do
+        with {:ok, key} <- import_local(name, org, public_key_file, private_key_file) do
+          Shell.info("\nSuccess. Key information:")
+          render_key(%{"name" => name, "key" => key})
+        else
+          error ->
+            Shell.render_error(error)
+        end
+      else
+        with {:ok, key} <- import_local(name, org, public_key_file, private_key_file),
+             {:ok, %{"data" => key}} <- create_remote(name, key, org) do
+          Shell.info("\nSuccess. Key information:")
+          render_key(key)
+        else
+          error ->
+            Shell.render_error(error)
+        end
+      end
+    end
+  end
+
+  def export(key, org, opts) do
+    path = opts[:path] || NervesHubCLI.home_dir()
+
+    with :ok <- File.mkdir_p(path),
+         {:ok, public_key, private_key} <- Shell.request_keys(org, key),
+         filename <- key_tar_file_name(path, org, key),
+         {:ok, tar} <- :erl_tar.open(to_charlist(filename), [:write, :compressed]),
+         :ok <- :erl_tar.add(tar, {~c"#{key}.pub", public_key}, []),
+         :ok <- :erl_tar.add(tar, {~c"#{key}.priv", private_key}, []),
+         :ok <- :erl_tar.close(tar) do
+      Shell.info("Fwup keys exported to: #{filename}")
+    else
+      error -> Shell.render_error(error)
+    end
+  end
+
+  def delete_remote(name, org) do
+    auth = Shell.request_auth()
+    Shell.info("Deleting signing key '#{name}' from NervesHub")
+    NervesHubCLI.API.Key.delete(org, name, auth)
+  end
+
+  # TODO handle file not found
+  def delete_local(name, org) do
+    Shell.info("Deleting signing key '#{name}' locally")
+    NervesHubCLI.Key.delete(org, name)
+  end
+
+  defp create_local(name, org) do
+    Shell.info("Creating a firmware signing key pair named '#{name}'.")
+    Shell.info("")
+    Shell.info("The private key is stored locally and must be protected by a password.")
+    Shell.info("If you are sharing the firmware signing private key with others,")
+    Shell.info("please choose an appropriate password.")
+    Shell.info("")
+    key_password = Shell.password_get("Signing key password for '#{name}':")
+
+    with {:ok, public_key_file, private_key_file} =
+           NervesHubCLI.Key.create(org, name, key_password),
+         {:ok, public_key} <- File.read(public_key_file) do
+      Shell.info("")
+      Shell.info("Firmware public key written to '#{public_key_file}'.")
+      Shell.info("Password-protected firmware private key written to '#{private_key_file}'.")
+      {:ok, public_key}
+    end
+  end
+
+  defp create_remote(name, key, org) do
+    Shell.info("\nRegistering the firmware signing public key '#{name}' with NervesHub.")
+    auth = Shell.request_auth()
+    NervesHubCLI.API.Key.create(org, name, key, auth)
+  end
+
+  defp import_local(name, org, public_key_file, private_key_file) do
+    Shell.info("\nPlease enter a password to protect the firmware signing private key.")
+    key_password = Shell.password_get("Signing key password for '#{name}':")
+
+    with {:ok, public_key_file, _private_key_file} =
+           NervesHubCLI.Key.import(org, name, key_password, public_key_file, private_key_file),
+         {:ok, public_key} <- File.read(public_key_file) do
+      {:ok, public_key}
+    end
+  end
+
+  defp render_keys([]) do
+    Shell.info("No firmware signing keys have been created.")
+  end
+
+  defp render_keys(keys) when is_list(keys) do
+    Shell.info("\nFirmware signing keys:")
+
+    Enum.each(keys, fn params ->
+      Shell.info("------------")
+
+      render_key(params)
+    end)
+
+    Shell.info("------------")
+    Shell.info("")
+  end
+
+  defp render_key(params) do
+    Shell.info("  name:       #{params["name"]}")
+    Shell.info("  public key: #{params["key"]}")
+  end
+
+  defp key_tar_file_name(path, org, key),
+    do: Path.join(path, "nerves_hub-fwup-keys-#{org}-#{key}.tar.gz")
+end

--- a/lib/nerves_hub_cli/cli/key.ex
+++ b/lib/nerves_hub_cli/cli/key.ex
@@ -6,11 +6,10 @@ defmodule NervesHubCLI.CLI.Key do
   @moduledoc """
   Manages firmware signing keys
 
-  Firmware signing keys consist of public and private keys. The `mix
-  nerves_hub.key` task manages both pieces for you. Private signing keys are
-  password-protected and are NEVER sent to NervesHub or any other server.
-  Public keys, however, are registered with NervesHub and embedded in your
-  firmware.
+  Firmware signing keys consist of public and private keys. The `nerves_hub key` 
+  task manages both pieces for you. Private signing keys are password-protected 
+  and are NEVER sent to NervesHub or any other server. Public keys, however, are 
+  registered with NervesHub and embedded in your firmware.
 
   Signing keys are stored in `~/.nerves-hub/keys`. Keys may be shared between
   developers by copying the files in this folder.
@@ -31,7 +30,7 @@ defmodule NervesHubCLI.CLI.Key do
 
   List the keys known to NervesHub
 
-      mix nerves_hub.key list
+      nerves_hub key list
 
   ### Command-line options
 
@@ -42,7 +41,7 @@ defmodule NervesHubCLI.CLI.Key do
   Create a new firmware signing key pair with the specified name and register
   the public key with NervesHub
 
-      mix nerves_hub.key create NAME
+      nerves_hub key create NAME
 
   ### Command-line options
 
@@ -52,7 +51,7 @@ defmodule NervesHubCLI.CLI.Key do
 
   Delete a signing key locally and on NervesHub
 
-      mix nerves_hub.key delete NAME
+      nerves_hub key delete NAME
 
   ### Command-line options
 
@@ -63,7 +62,7 @@ defmodule NervesHubCLI.CLI.Key do
 
   Import an existing key locally and on NervesHub
 
-      mix nerves_hub.key import NAME PUBLIC_KEY_FILE PRIVATE_KEY_FILE
+      nerves_hub key import NAME PUBLIC_KEY_FILE PRIVATE_KEY_FILE
 
   ### Command-line options
 
@@ -73,7 +72,7 @@ defmodule NervesHubCLI.CLI.Key do
 
   Export a signing key to a tar.gz archive.
 
-      mix nerves_hub.key export NAME
+      nerves_hub key export NAME
 
   ### Command-line options
 
@@ -116,16 +115,16 @@ defmodule NervesHubCLI.CLI.Key do
   @spec render_help() :: no_return()
   def render_help() do
     Shell.raise("""
-    Invalid arguments to `mix nerves_hub.key`.
+    Invalid arguments to `nerves_hub key`.
 
     Usage:
-      mix nerves_hub.key list
-      mix nerves_hub.key create NAME
-      mix nerves_hub.key delete NAME
-      mix nerves_hub.key import NAME PUBLIC_KEY_FILE PRIVATE_KEY_FILE
-      mix nerves_hub.key export NAME
+      nerves_hub key list
+      nerves_hub key create NAME
+      nerves_hub key delete NAME
+      nerves_hub key import NAME PUBLIC_KEY_FILE PRIVATE_KEY_FILE
+      nerves_hub key export NAME
 
-    Run `mix help nerves_hub.key` for more information.
+    Run `nerves_hub help key` for more information.
     """)
   end
 
@@ -161,7 +160,7 @@ defmodule NervesHubCLI.CLI.Key do
       The key '#{name}' already exists.
 
       Please choose a different name or delete by
-      running `mix nerves_hub.key delete #{name} [--local]`
+      running `nerves_hub key delete #{name} [--local]`
       """)
     else
       if Keyword.get(opts, :local, false) do

--- a/lib/nerves_hub_cli/cli/key.ex
+++ b/lib/nerves_hub_cli/cli/key.ex
@@ -3,8 +3,6 @@ defmodule NervesHubCLI.CLI.Key do
 
   alias NervesHubCLI.CLI.Shell
 
-  @shortdoc "Manages firmware signing keys"
-
   @moduledoc """
   Manages firmware signing keys
 

--- a/lib/nerves_hub_cli/cli/org.ex
+++ b/lib/nerves_hub_cli/cli/org.ex
@@ -29,25 +29,25 @@ defmodule NervesHubCLI.CLI.Org do
 
   List the users and their role for the organization.
 
-      mix nerves_hub.org user list
+      nerves_hub user list
 
   ## user add
 
   Add an existing user to an org with a role.
 
-      mix nerves_hub.org user add USERNAME ROLE
+      nerves_hub user add USERNAME ROLE
 
   ## user update
 
   Update an existing user in your org with a new role.
 
-      mix nerves_hub.org user update USERNAME ROLE
+      nerves_hub user update USERNAME ROLE
 
   ## user remove
 
   Remove an existing user from having a role in your organization.
 
-      mix nerves_hub.org user remove USERNAME
+      nerves_hub user remove USERNAME
   """
 
   @switches [
@@ -81,15 +81,15 @@ defmodule NervesHubCLI.CLI.Org do
   @spec render_help() :: no_return()
   def render_help() do
     Shell.raise("""
-    Invalid arguments to `mix nerves_hub.org`.
+    Invalid arguments to `nerves_hub user`.
 
     Usage:
-      mix nerves_hub.org user list
-      mix nerves_hub.org user add USERNAME ROLE
-      mix nerves_hub.org user update USERNAME ROLE
-      mix nerves_hub.org user remove USERNAME
+      nerves_hub user list
+      nerves_hub user add USERNAME ROLE
+      nerves_hub user update USERNAME ROLE
+      nerves_hub user remove USERNAME
 
-    Run `mix help nerves_hub.org` for more information.
+    Run `nerves_hub help org` for more information.
     """)
   end
 

--- a/lib/nerves_hub_cli/cli/org.ex
+++ b/lib/nerves_hub_cli/cli/org.ex
@@ -1,0 +1,187 @@
+defmodule NervesHubCLI.CLI.Org do
+  import NervesHubCLI.CLI.Utils
+
+  alias NervesHubCLI.CLI.Shell
+
+  @shortdoc "Manages an organization"
+
+  @moduledoc """
+  Manages an organization
+
+  # Managing user roles
+
+  The following functions allow the management of user roles within your organization.
+  Roles are a way of granting users a permission level so they may perform
+  actions for your org. The following is a list of valid roles in order of
+  highest role to lowest role:
+
+    * `admin`
+    * `delete`
+    * `write`
+    * `read`
+
+  NervesHub will validate all actions with your user role. If an action you are
+  trying to perform requires `write`, the user performing the action will be
+  required to have an org role of `write` or higher (`admin`, `delete`).
+
+  Managing user roles in your org will require that your user has the org role of
+  `admin`.
+
+  ## user list
+
+  List the users and their role for the organization.
+
+      mix nerves_hub.org user list
+
+  ## user add
+
+  Add an existing user to an org with a role.
+
+      mix nerves_hub.org user add USERNAME ROLE
+
+  ## user update
+
+  Update an existing user in your org with a new role.
+
+      mix nerves_hub.org user update USERNAME ROLE
+
+  ## user remove
+
+  Remove an existing user from having a role in your organization.
+
+      mix nerves_hub.org user remove USERNAME
+  """
+
+  @switches [
+    org: :string
+  ]
+
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
+    org = org(opts)
+
+    case args do
+      ["user", "list"] ->
+        user_list(org)
+
+      ["user", "add", username, role] ->
+        user_add(org, username, role)
+
+      ["user", "update", username, role] ->
+        user_update(org, username, role)
+
+      ["user", "remove", username] ->
+        user_remove(org, username)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.org`.
+
+    Usage:
+      mix nerves_hub.org user list
+      mix nerves_hub.org user add USERNAME ROLE
+      mix nerves_hub.org user update USERNAME ROLE
+      mix nerves_hub.org user remove USERNAME
+
+    Run `mix help nerves_hub.org` for more information.
+    """)
+  end
+
+  def user_list(org) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.OrgUser.list(org, auth) do
+      {:ok, %{"data" => users}} ->
+        render_users(users)
+
+      error ->
+        Shell.info("Failed to list org users \nreason: #{inspect(error)}")
+    end
+  end
+
+  def user_add(org, username, role, auth \\ nil) do
+    Shell.info("")
+    Shell.info("Adding user '#{username}' to org '#{org}' with role '#{role}'...")
+
+    auth = auth || Shell.request_auth()
+
+    case NervesHubCLI.API.OrgUser.add(org, username, String.to_atom(role), auth) do
+      {:ok, %{"data" => %{} = _org_user}} ->
+        Shell.info("User '#{username}' was added.")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def user_update(org, username, role) do
+    Shell.info("")
+    Shell.info("Updating user '#{username}' in org '#{org}' to role '#{role}'...")
+
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.OrgUser.update(org, username, String.to_atom(role), auth) do
+      {:ok, %{"data" => %{} = _org_user}} ->
+        Shell.info("User '#{username}' was updated.")
+
+      {:error, %{"errors" => %{"detail" => "Not Found"}}} ->
+        Shell.error("""
+        '#{username}' is not a user in the organization '#{org}'.
+        """)
+
+        if Shell.yes?("Would you like to add them?") do
+          user_add(org, username, role, auth)
+        end
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def user_remove(org, username) do
+    Shell.info("")
+    Shell.info("Removing user '#{username}' from org '#{org}'...")
+
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.OrgUser.remove(org, username, auth) do
+      {:ok, ""} ->
+        Shell.info("User '#{username}' was removed.")
+
+      {:error, %{"errors" => %{"detail" => "Not Found"}}} ->
+        Shell.error("""
+        '#{username}' is not a user in the organization '#{org}'
+        """)
+
+      error ->
+        IO.inspect(error)
+        Shell.render_error(error)
+    end
+  end
+
+  defp render_users(users) when is_list(users) do
+    Shell.info("\nOrganization users:")
+
+    Enum.each(users, fn params ->
+      Shell.info("------------")
+
+      render_user(params)
+    end)
+
+    Shell.info("------------")
+    Shell.info("")
+  end
+
+  defp render_user(params) do
+    Shell.info("  username:   #{params["username"]}")
+    Shell.info("  role:       #{params["role"]}")
+  end
+end

--- a/lib/nerves_hub_cli/cli/org.ex
+++ b/lib/nerves_hub_cli/cli/org.ex
@@ -3,8 +3,6 @@ defmodule NervesHubCLI.CLI.Org do
 
   alias NervesHubCLI.CLI.Shell
 
-  @shortdoc "Manages an organization"
-
   @moduledoc """
   Manages an organization
 

--- a/lib/nerves_hub_cli/cli/product.ex
+++ b/lib/nerves_hub_cli/cli/product.ex
@@ -12,7 +12,7 @@ defmodule NervesHubCLI.CLI.Product do
   product. This information can be passed by specifying one or all of the command
   line options.
 
-      mix nerves_hub.product create
+      nerves_hub product create
 
   ### Command-line options
 
@@ -20,11 +20,11 @@ defmodule NervesHubCLI.CLI.Product do
 
   ## list
 
-      mix nerves_hub.product list
+      nerves_hub product list
 
   ## delete
 
-      mix nerves_hub.product delete [product_name]
+      nerves_hub product delete [product_name]
 
   ## update
 
@@ -36,7 +36,7 @@ defmodule NervesHubCLI.CLI.Product do
 
   Change product name
 
-      mix nerves_hub.product update example name example_new
+      nerves_hub product update example name example_new
 
   # Managing user roles
 
@@ -61,25 +61,25 @@ defmodule NervesHubCLI.CLI.Product do
 
   List the users and their role for the product.
 
-      mix nerves_hub.product user list PRODUCT_NAME
+      nerves_hub product user list PRODUCT_NAME
 
   ## user add
 
   Add an existing user to a product with a role.
 
-      mix nerves_hub.product user add PRODUCT_NAME USERNAME ROLE
+      nerves_hub product user add PRODUCT_NAME USERNAME ROLE
 
   ## user update
 
   Update an existing user for your product with a new role.
 
-      mix nerves_hub.product user update PRODUCT_NAME USERNAME ROLE
+      nerves_hub product user update PRODUCT_NAME USERNAME ROLE
 
   ## user remove
 
   Remove an existing user from having a role for your product.
 
-      mix nerves_hub.product user remove PRODUCT_NAME USERNAME
+      nerves_hub product user remove PRODUCT_NAME USERNAME
   """
 
   @switches [
@@ -126,20 +126,20 @@ defmodule NervesHubCLI.CLI.Product do
   @spec render_help() :: no_return()
   def render_help() do
     Shell.raise("""
-    Invalid arguments to `mix nerves_hub.product`.
+    Invalid arguments to `nerves_hub product`.
 
     Usage:
-      mix nerves_hub.product list
-      mix nerves_hub.product create
-      mix nerves_hub.product delete PRODUCT_NAME
-      mix nerves_hub.product update PRODUCT_NAME KEY VALUE
+      nerves_hub product list
+      nerves_hub product create
+      nerves_hub product delete PRODUCT_NAME
+      nerves_hub product update PRODUCT_NAME KEY VALUE
 
-      mix nerves_hub.product user list PRODUCT_NAME
-      mix nerves_hub.product user add PRODUCT_NAME USERNAME ROLE
-      mix nerves_hub.product user update PRODUCT_NAME USERNAME ROLE
-      mix nerves_hub.product user remove PRODUCT_NAME USERNAME ROLE
+      nerves_hub product user list PRODUCT_NAME
+      nerves_hub product user add PRODUCT_NAME USERNAME ROLE
+      nerves_hub product user update PRODUCT_NAME USERNAME ROLE
+      nerves_hub product user remove PRODUCT_NAME USERNAME ROLE
 
-    Run `mix help nerves_hub.product` for more information.
+    Run `nerves_hub help product` for more information.
     """)
   end
 

--- a/lib/nerves_hub_cli/cli/product.ex
+++ b/lib/nerves_hub_cli/cli/product.ex
@@ -1,0 +1,322 @@
+defmodule NervesHubCLI.CLI.Product do
+  import NervesHubCLI.CLI.Utils
+
+  alias NervesHubCLI.CLI.Shell
+
+  @shortdoc "Manages your products"
+
+  @moduledoc """
+  Manages your products.
+
+  ## create
+
+  Create a new NervesHub product. The shell will prompt for information about the
+  product. This information can be passed by specifying one or all of the command
+  line options.
+
+      mix nerves_hub.product create
+
+  ### Command-line options
+
+    * `--name` - (Optional) The product name
+
+  ## list
+
+      mix nerves_hub.product list
+
+  ## delete
+
+      mix nerves_hub.product delete [product_name]
+
+  ## update
+
+  Update product metadata.
+
+  Call `list` to retrieve product names and metadata keys
+
+  ### Examples
+
+  Change product name
+
+      mix nerves_hub.product update example name example_new
+
+  # Managing user roles
+
+  The following functions allow the management of user roles within your product.
+  Roles are a way of granting users a permission level so they may perform
+  actions for your product. The following is a list of valid roles in order of
+  highest role to lowest role:
+
+    * `admin`
+    * `delete`
+    * `write`
+    * `read`
+
+  NervesHub will validate all actions with your user role. If an action you are
+  trying to perform requires `write`, the user performing the action will be
+  required to have an org role of `write` or higher (`admin`, `delete`).
+
+  Managing user roles for your product will require that your user has the
+  product role of `admin`.
+
+  ## user list
+
+  List the users and their role for the product.
+
+      mix nerves_hub.product user list PRODUCT_NAME
+
+  ## user add
+
+  Add an existing user to a product with a role.
+
+      mix nerves_hub.product user add PRODUCT_NAME USERNAME ROLE
+
+  ## user update
+
+  Update an existing user for your product with a new role.
+
+      mix nerves_hub.product user update PRODUCT_NAME USERNAME ROLE
+
+  ## user remove
+
+  Remove an existing user from having a role for your product.
+
+      mix nerves_hub.product user remove PRODUCT_NAME USERNAME
+  """
+
+  @switches [
+    org: :string,
+    name: :string
+  ]
+
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
+    org = org(opts)
+
+    case args do
+      ["list"] ->
+        list(org)
+
+      ["create"] ->
+        create(org, opts)
+
+      ["delete", product_name] ->
+        delete(org, product_name)
+
+      ["update", product, key, value] ->
+        update(org, product, key, value)
+
+      ["user", "list", product] ->
+        user_list(org, product)
+
+      ["user", "add", product, username, role] ->
+        user_add(org, product, username, role)
+
+      ["user", "update", product, username, role] ->
+        user_update(org, product, username, role)
+
+      ["user", "remove", product, username] ->
+        user_remove(org, product, username)
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.product`.
+
+    Usage:
+      mix nerves_hub.product list
+      mix nerves_hub.product create
+      mix nerves_hub.product delete PRODUCT_NAME
+      mix nerves_hub.product update PRODUCT_NAME KEY VALUE
+
+      mix nerves_hub.product user list PRODUCT_NAME
+      mix nerves_hub.product user add PRODUCT_NAME USERNAME ROLE
+      mix nerves_hub.product user update PRODUCT_NAME USERNAME ROLE
+      mix nerves_hub.product user remove PRODUCT_NAME USERNAME ROLE
+
+    Run `mix help nerves_hub.product` for more information.
+    """)
+  end
+
+  def list(org) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Product.list(org, auth) do
+      {:ok, %{"data" => []}} ->
+        Shell.info("No products have been created.")
+
+      {:ok, %{"data" => products}} ->
+        Shell.info("")
+        Shell.info("Products:")
+
+        Enum.each(products, fn params ->
+          Shell.info("------------")
+
+          render_product(params)
+          |> String.trim_trailing()
+          |> Shell.info()
+        end)
+
+        Shell.info("")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def create(org, opts) do
+    config = Mix.Project.config()
+
+    name = opts[:name] || config[:name] || config[:app] || Shell.prompt("Product name:")
+    name = to_string(name)
+
+    Shell.info("")
+    Shell.info("Creating product '#{name}'...")
+
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Product.create(org, name, auth) do
+      {:ok, %{"data" => %{} = _product}} ->
+        Shell.info("Product '#{name}' created.")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def delete(org, product_name) do
+    if Shell.yes?("Delete product '#{product_name}'?") do
+      auth = Shell.request_auth()
+
+      case NervesHubCLI.API.Product.delete(org, product_name, auth) do
+        {:ok, ""} ->
+          Shell.info("Product deleted successfully.")
+
+        error ->
+          Shell.render_error(error)
+      end
+    end
+  end
+
+  def update(org, product, key, value) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.Product.update(org, product, Map.put(%{}, key, value), auth) do
+      {:ok, %{"data" => product}} ->
+        Shell.info("")
+        Shell.info("Product updated:")
+
+        render_product(product)
+        |> String.trim_trailing()
+        |> Shell.info()
+
+        Shell.info("")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def user_list(org, product) do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.ProductUser.list(org, product, auth) do
+      {:ok, %{"data" => users}} ->
+        render_users(users)
+
+      error ->
+        Shell.info("Failed to list product users \nreason: #{inspect(error)}")
+    end
+  end
+
+  def user_add(org, product, username, role, auth \\ nil) do
+    Shell.info("")
+    Shell.info("Adding user '#{username}' to product '#{product}' with role '#{role}'...")
+
+    auth = auth || Shell.request_auth()
+
+    case NervesHubCLI.API.ProductUser.add(org, product, username, String.to_atom(role), auth) do
+      {:ok, %{"data" => %{} = _product_user}} ->
+        Shell.info("User '#{username}' was added.")
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def user_update(org, product, username, role) do
+    Shell.info("")
+    Shell.info("Updating user '#{username}' in product '#{product}' to role '#{role}'...")
+
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.ProductUser.update(org, product, username, String.to_atom(role), auth) do
+      {:ok, %{"data" => %{} = _product_user}} ->
+        Shell.info("User '#{username}' was updated.")
+
+      {:error, %{"errors" => %{"detail" => "Not Found"}}} ->
+        Shell.error("""
+        '#{username}' is not a user for product '#{product}'.
+        """)
+
+        if Shell.yes?("Would you like to add them?") do
+          user_add(org, product, username, role, auth)
+        end
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def user_remove(org, product, username) do
+    Shell.info("")
+    Shell.info("Removing user '#{username}' from product '#{product}'...")
+
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.ProductUser.remove(org, product, username, auth) do
+      {:ok, ""} ->
+        Shell.info("User '#{username}' was removed.")
+
+      {:error, %{"errors" => %{"detail" => "Not Found"}}} ->
+        Shell.error("""
+        '#{username}' is not a user for the product '#{product}'
+        """)
+
+      error ->
+        IO.inspect(error)
+        Shell.render_error(error)
+    end
+  end
+
+  defp render_product(params) do
+    """
+      name: #{params["name"]}
+    """
+  end
+
+  defp render_users(users) when is_list(users) do
+    Shell.info("\nProduct users:")
+
+    Enum.each(users, fn params ->
+      Shell.info("------------")
+
+      render_user(params)
+    end)
+
+    Shell.info("------------")
+    Shell.info("")
+  end
+
+  defp render_user(params) do
+    Shell.info("  username:   #{params["username"]}")
+    Shell.info("  role:       #{params["role"]}")
+  end
+end

--- a/lib/nerves_hub_cli/cli/product.ex
+++ b/lib/nerves_hub_cli/cli/product.ex
@@ -3,8 +3,6 @@ defmodule NervesHubCLI.CLI.Product do
 
   alias NervesHubCLI.CLI.Shell
 
-  @shortdoc "Manages your products"
-
   @moduledoc """
   Manages your products.
 
@@ -171,10 +169,13 @@ defmodule NervesHubCLI.CLI.Product do
     end
   end
 
-  def create(org, opts) do
-    config = Mix.Project.config()
+  def create(org, _opts) do
+    default_name =
+      File.cwd!()
+      |> Path.split()
+      |> List.last()
 
-    name = opts[:name] || config[:name] || config[:app] || Shell.prompt("Product name:")
+    name = Shell.prompt("Product name (default #{default_name}):") || default_name
     name = to_string(name)
 
     Shell.info("")

--- a/lib/nerves_hub_cli/cli/shell.ex
+++ b/lib/nerves_hub_cli/cli/shell.ex
@@ -1,0 +1,148 @@
+defmodule NervesHubCLI.CLI.Shell do
+  alias Mix.NervesHubCLI.Utils
+
+  @spec info(IO.ANSI.ansidata()) :: :ok
+  def info(output) do
+    IO.puts(output)
+  end
+
+  @spec error(IO.ANSI.ansidata()) :: :ok
+  def error(output) do
+    IO.ANSI.format([:red, output])
+    |> IO.puts()
+  end
+
+  @spec raise(String.t()) :: no_return()
+  def raise(output) do
+    error(output)
+    System.halt(1)
+  end
+
+  @spec prompt(String.t()) :: String.t()
+  def prompt(output) do
+    IO.gets(output)
+    |> String.trim()
+  end
+
+  @spec yes?(String.t()) :: boolean()
+  def yes?(message) do
+    System.get_env("NERVES_HUB_NON_INTERACTIVE") ||
+      IO.ANSI.format([message, :yellow, " yN "])
+      |> IO.gets()
+      |> then(fn resp ->
+        is_binary(resp) and String.trim(resp) in ["y", "Y", "yes", "YES", "Yes"]
+      end)
+  end
+
+  @spec request_auth() :: NervesHubCLI.API.Auth.t() | nil
+  def request_auth() do
+    if token = Utils.token() do
+      %NervesHubCLI.API.Auth{token: token}
+    end
+  end
+
+  def request_password(_prompt, 0) do
+    {:error, :failed_password}
+  end
+
+  def request_keys(org, name) do
+    request_keys(org, name, "Local signing key password for '#{name}': ")
+  end
+
+  def request_keys(org, name, prompt) do
+    env_pub_key = System.get_env("NERVES_HUB_FW_PUBLIC_KEY")
+    env_priv_key = System.get_env("NERVES_HUB_FW_PRIVATE_KEY")
+
+    if env_pub_key != nil and env_priv_key != nil do
+      {:ok, env_pub_key, env_priv_key}
+    else
+      key_password = password_get(prompt)
+      NervesHubCLI.Key.get(org, name, key_password)
+    end
+  end
+
+  # Password prompt that hides input by every 1ms
+  # clearing the line with stderr
+  @spec password_get(String.t()) :: String.t()
+  def password_get(prompt) do
+    password_clean(prompt)
+    |> String.trim()
+  end
+
+  @dialyzer [{:no_return, render_error: 1}, {:no_fail_call, render_error: 1}]
+
+  @spec render_error([{:error, any()}] | {:error, any()}, boolean() | nil) ::
+          :ok | no_return()
+  def render_error(errors, halt? \\ true) do
+    _ = do_render_error(errors)
+
+    if halt? do
+      System.halt(1)
+    else
+      :ok
+    end
+  end
+
+  @spec do_render_error(any()) :: :ok
+  def do_render_error(errors) when is_list(errors) do
+    Enum.each(errors, &do_render_error/1)
+  end
+
+  def do_render_error({error, reasons}) when is_list(reasons) do
+    error("#{error}")
+    for reason <- reasons, do: error("  #{reason}")
+    :ok
+  end
+
+  def do_render_error({:error, reason}) when is_binary(reason) do
+    error(reason)
+  end
+
+  def do_render_error({:error, %{"status" => "forbidden"}}) do
+    error("Invalid credentials")
+    error("Your user token has either expired or has been revoked.")
+    error("Please authenticate again:")
+    error("  mix nerves_hub.user auth")
+  end
+
+  def do_render_error({:error, %{"status" => reason}}) do
+    error(reason)
+  end
+
+  def do_render_error({:error, %{"errors" => reason}}) when is_binary(reason) do
+    error(reason)
+  end
+
+  def do_render_error({:error, %{"errors" => reasons}}) when is_list(reasons) do
+    error("HTTP error")
+    for {key, reason} <- reasons, do: error("  #{key}: #{reason}")
+    :ok
+  end
+
+  def do_render_error(error) do
+    error("Unhandled error: #{inspect(error)}")
+  end
+
+  defp password_clean(prompt) do
+    pid = spawn_link(fn -> loop(prompt) end)
+    ref = make_ref()
+    value = IO.gets(prompt <> " ")
+
+    send(pid, {:done, self(), ref})
+    receive do: ({:done, ^pid, ^ref} -> :ok)
+
+    value
+  end
+
+  defp loop(prompt) do
+    receive do
+      {:done, parent, ref} ->
+        send(parent, {:done, self(), ref})
+        IO.write(:standard_error, "\e[2K\r")
+    after
+      1 ->
+        IO.write(:standard_error, "\e[2K\r#{prompt} ")
+        loop(prompt)
+    end
+  end
+end

--- a/lib/nerves_hub_cli/cli/shell.ex
+++ b/lib/nerves_hub_cli/cli/shell.ex
@@ -38,6 +38,8 @@ defmodule NervesHubCLI.CLI.Shell do
   def request_auth() do
     if token = Utils.token() do
       %NervesHubCLI.API.Auth{token: token}
+    else
+      __MODULE__.raise("You are not authenticated")
     end
   end
 

--- a/lib/nerves_hub_cli/cli/shell.ex
+++ b/lib/nerves_hub_cli/cli/shell.ex
@@ -1,5 +1,5 @@
 defmodule NervesHubCLI.CLI.Shell do
-  alias Mix.NervesHubCLI.Utils
+  alias NervesHubCLI.CLI.Utils
 
   @spec info(IO.ANSI.ansidata()) :: :ok
   def info(message) do

--- a/lib/nerves_hub_cli/cli/shell.ex
+++ b/lib/nerves_hub_cli/cli/shell.ex
@@ -2,14 +2,17 @@ defmodule NervesHubCLI.CLI.Shell do
   alias Mix.NervesHubCLI.Utils
 
   @spec info(IO.ANSI.ansidata()) :: :ok
-  def info(output) do
-    IO.puts(output)
+  def info(message) do
+    IO.puts(IO.ANSI.format(message))
   end
 
   @spec error(IO.ANSI.ansidata()) :: :ok
-  def error(output) do
-    IO.ANSI.format([:red, output])
-    |> IO.puts()
+  def error(message) do
+    IO.puts(:stderr, IO.ANSI.format(red(message)))
+  end
+
+  defp red(message) do
+    [:red, :bright, message]
   end
 
   @spec raise(String.t()) :: no_return()
@@ -19,8 +22,8 @@ defmodule NervesHubCLI.CLI.Shell do
   end
 
   @spec prompt(String.t()) :: String.t()
-  def prompt(output) do
-    IO.gets(output)
+  def prompt(message) do
+    IO.gets(message <> " ")
     |> String.trim()
   end
 

--- a/lib/nerves_hub_cli/cli/user.ex
+++ b/lib/nerves_hub_cli/cli/user.ex
@@ -4,8 +4,6 @@ defmodule NervesHubCLI.CLI.User do
   alias NervesHubCLI.{User, Config}
   alias NervesHubCLI.CLI.Shell
 
-  @shortdoc "Manages your NervesHub user account"
-
   @moduledoc """
   Manage your NervesHub user account.
 

--- a/lib/nerves_hub_cli/cli/user.ex
+++ b/lib/nerves_hub_cli/cli/user.ex
@@ -10,16 +10,16 @@ defmodule NervesHubCLI.CLI.User do
   Users are authenticated to the NervesHub API with a user access token
   presented in each request. This token can be manually supplied with the
   `NERVES_HUB_TOKEN` or `NH_TOKEN` environment variables. Or you can use
-  `mix nerves_hub.user auth` to authenticate with the web, generate a token,
+  `nerves_hub user auth` to authenticate with the web, generate a token,
   and save it locally in your config in `$NERVES_HUB_HOME`
 
   ## whoami
 
-      mix nerves_hub.user whoami
+      nerves_hub user whoami
 
   ## auth
 
-      mix nerves_hub.user auth
+      nerves_hub user auth
 
   ### Command-line options
 
@@ -27,7 +27,7 @@ defmodule NervesHubCLI.CLI.User do
 
   ## deauth
 
-      mix nerves_hub.user deauth
+      nerves_hub user deauth
 
   ### Command-line options
 
@@ -63,15 +63,15 @@ defmodule NervesHubCLI.CLI.User do
   @spec render_help() :: no_return()
   def render_help() do
     Shell.raise("""
-    Invalid arguments to `mix nerves_hub.user`.
+    Invalid arguments to `nerves_hub user`.
 
     Usage:
 
-      mix nerves_hub.user whoami
-      mix nerves_hub.user auth
-      mix nerves_hub.user deauth
+      nerves_hub user whoami
+      nerves_hub user auth
+      nerves_hub user deauth
 
-    Run `mix help nerves_hub.user` for more information.
+    Run `nerves_hub help user` for more information.
     """)
   end
 

--- a/lib/nerves_hub_cli/cli/user.ex
+++ b/lib/nerves_hub_cli/cli/user.ex
@@ -1,0 +1,123 @@
+defmodule NervesHubCLI.CLI.User do
+  import NervesHubCLI.CLI.Utils
+
+  alias NervesHubCLI.{User, Config}
+  alias NervesHubCLI.CLI.Shell
+
+  @shortdoc "Manages your NervesHub user account"
+
+  @moduledoc """
+  Manage your NervesHub user account.
+
+  Users are authenticated to the NervesHub API with a user access token
+  presented in each request. This token can be manually supplied with the
+  `NERVES_HUB_TOKEN` or `NH_TOKEN` environment variables. Or you can use
+  `mix nerves_hub.user auth` to authenticate with the web, generate a token,
+  and save it locally in your config in `$NERVES_HUB_HOME`
+
+  ## whoami
+
+      mix nerves_hub.user whoami
+
+  ## auth
+
+      mix nerves_hub.user auth
+
+  ### Command-line options
+
+    * `--note` - (Optional) Note for the access token that is generated. Defaults to `hostname`
+
+  ## deauth
+
+      mix nerves_hub.user deauth
+
+  ### Command-line options
+
+    * `--path` - (Optional) A local location for exporting certificate.
+  """
+
+  @switches [
+    note: :string,
+    path: :string,
+    use_peer_auth: :boolean
+  ]
+
+  def run(args) do
+    {opts, args} = OptionParser.parse!(args, strict: @switches)
+
+    show_api_endpoint()
+
+    case args do
+      ["whoami"] ->
+        whoami()
+
+      ["auth"] ->
+        auth(opts)
+
+      ["deauth"] ->
+        deauth()
+
+      _ ->
+        render_help()
+    end
+  end
+
+  @spec render_help() :: no_return()
+  def render_help() do
+    Shell.raise("""
+    Invalid arguments to `mix nerves_hub.user`.
+
+    Usage:
+
+      mix nerves_hub.user whoami
+      mix nerves_hub.user auth
+      mix nerves_hub.user deauth
+
+    Run `mix help nerves_hub.user` for more information.
+    """)
+  end
+
+  def whoami do
+    auth = Shell.request_auth()
+
+    case NervesHubCLI.API.User.me(auth) do
+      {:ok, %{"data" => data}} ->
+        %{"name" => name, "email" => email} = data
+
+        Shell.info("""
+        name:  #{name}
+        email: #{email}
+        """)
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def auth(opts) do
+    username_or_email = Shell.prompt("Username or email address:") |> String.trim()
+    password = Shell.password_get("NervesHub password:") |> String.trim()
+    Shell.info("Authenticating...")
+
+    result = NervesHubCLI.API.User.login(username_or_email, password, opts[:note])
+
+    case result do
+      {:ok, %{"data" => %{"token" => token}}} ->
+        _ = Config.put(:token, token)
+        Shell.info("Success")
+
+      {:error, %{"errors" => errors}} ->
+        Shell.error("Account authentication failed \n")
+        Shell.render_error(errors)
+
+      error ->
+        Shell.render_error(error)
+    end
+  end
+
+  def deauth() do
+    if Shell.yes?("Deauthorize the current user?") do
+      User.deauth()
+    end
+  end
+end

--- a/lib/nerves_hub_cli/cli/utils.ex
+++ b/lib/nerves_hub_cli/cli/utils.ex
@@ -15,6 +15,10 @@ defmodule NervesHubCLI.CLI.Utils do
     endpoint = NervesHubCLI.API.endpoint()
     uri = URI.parse(endpoint)
 
+    if is_nil(uri.host) do
+      Shell.raise("NervesHub URI was not set")
+    end
+
     Shell.info("NervesHub server: #{uri.host}:#{uri.port}")
   end
 

--- a/lib/nerves_hub_cli/cli/utils.ex
+++ b/lib/nerves_hub_cli/cli/utils.ex
@@ -86,22 +86,6 @@ defmodule NervesHubCLI.CLI.Utils do
   end
 
   @doc """
-  Return the path to the generated firmware bundle
-  """
-  @spec firmware() :: Path.t()
-  def firmware do
-    # TODO: what to replace these paths with?
-    # this is used in NervesHubCLI.CLI.Firmware for the commands 
-    # `nerves_hub firmware publish` and `nerves_hub firmware sign`
-    images_path =
-      (config()[:images_path] || Path.join([Mix.Project.build_path(), "nerves", "images"]))
-      |> Path.expand()
-
-    filename = "#{config()[:app]}.fw"
-    Path.join(images_path, filename)
-  end
-
-  @doc """
   Read the firmware metadata from the specified firmware bundle
   """
   @spec metadata(Path.t()) :: {:error, any()} | {:ok, map()}

--- a/lib/nerves_hub_cli/cli/utils.ex
+++ b/lib/nerves_hub_cli/cli/utils.ex
@@ -4,14 +4,13 @@ defmodule NervesHubCLI.CLI.Utils do
 
   @spec product(keyword()) :: String.t()
   def product(opts) do
-    # TODO: let's discuss the best default behavior here, if it should be changed
     # Currently, in order of priority:
     # - check if the product was passed into the command
     # - read the environment variables for product
     # - global config, which was set via `nerves_hub config set product "my_product_name"`
     # - raise with error message
     #
-    # Note: the default product name was changed to the directory that `nerves_hub product create` was called from.
+    # TODO: the default product name was changed to the directory that `nerves_hub product create` was called from.
     # Should we make current directory name a default option as well?
     product =
       Keyword.get(opts, :product) || System.get_env("NERVES_HUB_PRODUCT") || Config.get(:product) ||
@@ -53,7 +52,11 @@ defmodule NervesHubCLI.CLI.Utils do
 
   @spec org(keyword()) :: String.t()
   def org(opts) do
-    # TODO: similar to above. We should discuss the best case intended defaults
+    # Currently, in order of priority:
+    # - check if the org was passed into the command
+    # - read the environment variables for org
+    # - global config, which was set via `nerves_hub config set org "my_product_name"`
+    # - raise with error message
     org =
       Keyword.get(opts, :org) || System.get_env("NERVES_HUB_ORG") || Config.get(:org) ||
         Shell.raise("""
@@ -88,6 +91,8 @@ defmodule NervesHubCLI.CLI.Utils do
   @spec firmware() :: Path.t()
   def firmware do
     # TODO: what to replace these paths with?
+    # this is used in NervesHubCLI.CLI.Firmware for the commands 
+    # `nerves_hub firmware publish` and `nerves_hub firmware sign`
     images_path =
       (config()[:images_path] || Path.join([Mix.Project.build_path(), "nerves", "images"]))
       |> Path.expand()
@@ -216,32 +221,5 @@ defmodule NervesHubCLI.CLI.Utils do
     raise RuntimeError, "this shouldn't be used!!"
 
     Mix.Project.config()
-  end
-
-  # TODO: if mix tasks are not supported, this can be removed
-  defp org_from_env() do
-    if Application.get_env(:nerves_hub, :org) do
-      org = Application.get_env(:nerves_hub, :org)
-
-      Shell.raise("""
-
-      Specifying your NervesHub organization using the :nerves_hub application
-      environment is no longer supported.
-
-      Please edit your config.exs and replace:
-
-        config :nerves_hub, org: "#{org}"
-
-      With:
-
-        config :nerves_hub_cli, org: "#{org}"
-
-      Another source of this issue is having an old version of `:nerves_hub_link`.
-      If you are using `:nerves_hub_link`, make sure that you're using v0.8.0 or
-      later.
-      """)
-    else
-      Application.get_env(:nerves_hub_cli, :org)
-    end
   end
 end

--- a/lib/nerves_hub_cli/cli/utils.ex
+++ b/lib/nerves_hub_cli/cli/utils.ex
@@ -1,0 +1,215 @@
+defmodule NervesHubCLI.CLI.Utils do
+  alias NervesHubCLI.Config
+  alias NervesHubCLI.CLI.Shell
+
+  @spec product(keyword()) :: String.t()
+  def product(opts) do
+    Keyword.get(opts, :product) || config()[:name] || config()[:app]
+  end
+
+  @doc """
+  Print the API endpoint that's being used to communicate with the NervesHub server
+  """
+  @spec show_api_endpoint() :: :ok
+  def show_api_endpoint() do
+    endpoint = NervesHubCLI.API.endpoint()
+    uri = URI.parse(endpoint)
+
+    Shell.info("NervesHub server: #{uri.host}:#{uri.port}")
+  end
+
+  @spec org(keyword()) :: String.t()
+  def org(opts) do
+    # command-line options
+    # environment
+    # project
+    # user
+    # not found
+    org =
+      Keyword.get(opts, :org) || System.get_env("NERVES_HUB_ORG") ||
+        org_from_env() || Config.get(:org) ||
+        Shell.raise("""
+        Cound not determine organization
+        Organization is set in the following order
+
+          From the command line
+
+            --org org_name
+
+          By setting the environment variable NERVES_HUB_ORG
+
+            export NERVES_HUB_ORG=org_name
+
+          By setting it in the project's config.exs
+
+            config :nerves_hub_cli,
+              org: "org_name"
+
+          Your user org from the NervesHub config
+
+            NervesHubCLI.Config.get(:org)
+        """)
+
+    Shell.info("NervesHub organization: #{org}")
+    org
+  end
+
+  @doc """
+  Return the path to the generated firmware bundle
+  """
+  @spec firmware() :: Path.t()
+  def firmware do
+    images_path =
+      (config()[:images_path] || Path.join([Mix.Project.build_path(), "nerves", "images"]))
+      |> Path.expand()
+
+    filename = "#{config()[:app]}.fw"
+    Path.join(images_path, filename)
+  end
+
+  @doc """
+  Read the firmware metadata from the specified firmware bundle
+  """
+  @spec metadata(Path.t()) :: {:error, any()} | {:ok, map()}
+  def metadata(firmware) do
+    case System.cmd("fwup", ["-m", "-i", firmware]) do
+      {metadata, 0} ->
+        metadata =
+          metadata
+          |> String.trim()
+          |> String.split("\n")
+          |> Enum.map(&String.split(&1, "=", parts: 2))
+          |> Enum.map(fn [k, v] -> {String.trim(k, "meta-"), String.trim(v, "\"")} end)
+          |> Enum.into(%{})
+
+        {:ok, metadata}
+
+      {reason, _} ->
+        {:error, reason}
+    end
+  end
+
+  @spec fetch_metadata_item(String.t(), String.t()) :: {:ok, String.t()} | {:error, :not_found}
+  def fetch_metadata_item(metadata, key) when is_binary(key) do
+    {:ok, regex} = "#{key}=\"(?<item>[^\n]+)\"" |> Regex.compile()
+
+    case Regex.named_captures(regex, metadata) do
+      %{"item" => item} -> {:ok, item}
+      _ -> {:error, :not_found}
+    end
+  end
+
+  @spec get_metadata_item(String.t(), String.t(), any()) :: String.t() | nil
+  def get_metadata_item(metadata, key, default \\ nil) when is_binary(key) do
+    case fetch_metadata_item(metadata, key) do
+      {:ok, metadata_item} -> metadata_item
+      {:error, :not_found} -> default
+    end
+  end
+
+  @doc """
+  Turn map keys into strings
+  """
+  @spec stringify(map()) :: map()
+  def stringify(map) when is_map(map) do
+    for {key, val} <- map, do: {to_string(key), val}, into: %{}
+  end
+
+  @doc """
+  Split up a string of comma-separated tags
+
+  Invalid tags raise.
+
+    iex> Mix.NervesHubCLI.Utils.split_tag_string("a, b, c")
+    ["a", "b", "c"]
+
+    iex> Mix.NervesHubCLI.Utils.split_tag_string("a space tag, b, c")
+    ** (RuntimeError) Tag 'a space tag' should not contain white space
+
+    iex> Mix.NervesHubCLI.Utils.split_tag_string("\\"tag_in_quotes\\"")
+    ** (RuntimeError) Tag '\"tag_in_quotes\"' should not contain quotes
+
+  """
+  @spec split_tag_string(String.t()) :: [String.t()]
+  def split_tag_string(str) do
+    tags =
+      str
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+
+    Enum.each(tags, &check_valid_tag/1)
+
+    tags
+  end
+
+  @doc """
+  Takes the integer serial representation of a certificate serial number
+  and converts it to a hex string with `:` separators to match typical
+  output from OpenSSL
+  """
+  @spec serial_as_hex(binary | integer) :: binary
+  def serial_as_hex(serial_int) when is_integer(serial_int) do
+    serial_int
+    |> Integer.to_string(16)
+    |> to_charlist()
+    |> Enum.chunk_every(2)
+    |> Enum.join(":")
+  end
+
+  def serial_as_hex(serial_str) when is_binary(serial_str) do
+    String.to_integer(serial_str)
+    |> serial_as_hex()
+  end
+
+  @doc """
+  Get User Access Token for use with the session
+  """
+  def token(opts \\ []) do
+    opts[:token] ||
+      System.get_env("NERVES_HUB_TOKEN") || System.get_env("NH_TOKEN") ||
+      Config.get(:token)
+  end
+
+  defp check_valid_tag(tag) do
+    cond do
+      String.contains?(tag, [" ", "\t", "\n"]) ->
+        raise "Tag '#{tag}' should not contain white space"
+
+      String.contains?(tag, ["\"", "'"]) ->
+        raise "Tag '#{tag}' should not contain quotes"
+
+      true ->
+        :ok
+    end
+  end
+
+  defp config() do
+    Mix.Project.config()
+  end
+
+  defp org_from_env() do
+    if Application.get_env(:nerves_hub, :org) do
+      org = Application.get_env(:nerves_hub, :org)
+
+      Shell.raise("""
+
+      Specifying your NervesHub organization using the :nerves_hub application
+      environment is no longer supported.
+
+      Please edit your config.exs and replace:
+
+        config :nerves_hub, org: "#{org}"
+
+      With:
+
+        config :nerves_hub_cli, org: "#{org}"
+
+      Another source of this issue is having an old version of `:nerves_hub_link`.
+      If you are using `:nerves_hub_link`, make sure that you're using v0.8.0 or
+      later.
+      """)
+    else
+      Application.get_env(:nerves_hub_cli, :org)
+    end
+  end
+end

--- a/lib/nerves_hub_cli/cli/utils.ex
+++ b/lib/nerves_hub_cli/cli/utils.ex
@@ -63,6 +63,7 @@ defmodule NervesHubCLI.CLI.Utils do
   """
   @spec firmware() :: Path.t()
   def firmware do
+    # TODO: what to replace these paths with?
     images_path =
       (config()[:images_path] || Path.join([Mix.Project.build_path(), "nerves", "images"]))
       |> Path.expand()
@@ -188,6 +189,8 @@ defmodule NervesHubCLI.CLI.Utils do
   end
 
   defp config() do
+    raise RuntimeError, "this shouldn't be used!!"
+
     Mix.Project.config()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule NervesHubCLI.MixProject do
     [
       app: :nerves_hub_cli,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: docs(),

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule NervesHubCLI.MixProject do
       description: description(),
       package: package(),
       dialyzer: dialyzer(),
+      escript: escript(),
       preferred_cli_env: %{
         docs: :docs,
         "hex.publish": :docs,
@@ -65,6 +66,13 @@ defmodule NervesHubCLI.MixProject do
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"],
       source_ref: "v#{@version}",
       source_url: @source_url
+    ]
+  end
+
+  def escript do
+    [
+      main_module: NervesHubCLI.CLI,
+      name: :nerves_hub
     ]
   end
 end


### PR DESCRIPTION
## tl;dr

I added support to install NervesHubCLI as an escript, to evaluate whether this provides a better experience for working with NervesHub from the command line without configuring it with every project. It's quite rough around the edges

## Problem

I recently was invited to try out the NervesCloud beta by Lars and Josh. This was my first time setting up NervesHub, and unfortunately I found the process to be confusing. While NervesHubLink makes sense to add as a project dependency, I couldn't quite figure out how to work with the mix tasks for the CLI. 

I know that 2.0 is under active development and the docs are getting better with every commit, and that definitely would have helped with some of the issues I faced. However, one of the most confusing parts of this was configuring the CLI to correctly talk with the NervesHub instance (NervesCloud in this case), and then realizing that I need to run `mix nerves_hub.user auth` (previously there were no error messages, just a crash that the `%NervesHubCLI.API.Auth{}` struct was `nil`). I did get it working eventually, but while talking to Josh and Lars, I realized that NervesHubCLI may have a better user experience if it was a globally-installable CLI tool, with some persistent settings.

## Potential solutions

There are a number of different ways which this problem could be tackled. 

- A hex archive - similar to the `phx_new` generators, or `nerves_bootstrap`. Installation could be as simple as `mix archive.install hex nerves_hub_cli`
- `#! /usr/bin/env elixir` script, with some `Mix.install` commands. 
- Modifying the project to support installation as an escript

For the first option of distributing it as a hex archive, I think this makes the most sense, and would be the easiest. However, hex archives are supposed to be lightweight extensions of `Mix`, so unfortunately, it can't have dependencies to prevent conflicts with the project deps. Given that the CLI has web requests and cryptography functions, I don't think it's a good idea to try to go without any dependencies

I made some preliminary experiments with the Elixir script idea, but I found that the `Mix` module was not available in the environment, which meant that I couldn't easily reuse the current mix tasks found in this repo, as they make heavy use of that module.

I think escript makes the most sense, as it can be easily distributed and doesn't require a large number of changes.

## Changes

To build the dependency as an escript, I basically copied all of the mix tasks into the `NervesHubCLI.CLI` module. I removed references to `Mix`, and swapped out the task-specific modules used (such as `lib/mix/nerves_hub/*.ex`) into variants which didn't have `Mix` dependencies. For example, instead of using `Mix.Shell.yes?/1`, I created a variant which just reads stdio via `IO.gets/1` and checks to see if it is a positive response.

The command structure is now slightly different. Because it is no longer invoked with mix tasks, the command follows a command + subcommand structure. Examples:

-   `$ nerves_hub user whoami`
-   `$ nerves_hub device list`
-   `$ nerves_hub key create --name dev_key`

Additionally, there are some persistent config options which can now be set. I anticipate support for these can be expanded in the future, but the main one is the `uri` option:

-   `$ nerves_hub config set uri "https://manage.nervescloud.com"`
-   `$ nerves_hub config get uri`

## What's broken

This PR is definitely not ready. I wanted to showcase this early work, to see if this CLI experience is something which would be a beneficial change for the community. As such, I spent time to get some basic functions to work, but didn't spend a lot of time to polish. Some things which are definitely broken:

-   The `:ca_store` dependency stores the cert files in the `priv/` directory - which is not available for escripts. So I commented out portions of the HTTP API interface which used that.
-   There are still some places where `Mix` is used. For example, try searching for `Mix.Project.config()` in the `lib/nerves_hub_cli/cli/` folder. If you run a command which calls `Mix` it will crash
-   I didn't update the error messages/help docs. Error messages will still refer to the mix tasks
-   Testing is non existent at this point (though 99% of the changes are coping code from the mix tasks into their own modules)
-   You may need to specify the flags for `org` or `product` (or set them as environment variables: `NERVES_HUB_ORG` and `NERVES_HUB_PRODUCT`), since they aren't read from application config. 

## How to test it out

I'm assuming you are using the NervesCloud instance here, if not change the uri to point to your own instance.

```
mix escript.install git https://github.com/gworkman/nerves_hub_cli branch gw-make-escript

# Note: you may need to add the escript directory to your path. Follow the instructions from escript

nerves_hub config set uri "https://manage.nervescloud.com/"
nerves_hub user whoami
nerves_hub user auth
nerves_hub user whoami
nerves_hub firmware list --org my_org --product my_product

# to uninstall
mix escript.uninstall nerves_hub
```

## What's next

If this is something which is useful for the community, I'll keep working on this to polish it up. For the most part, I haven't touched anything which breaks the mix tasks (just the removed `:ca_store`, and added global config of the `uri`).

I'm happy to get some feedback, and also some input on some of my opinionated things (such as naming the executable to `nerves_hub` or the module names - `NervesHubCLI.CLI.*` isn't great imo, but I wasn't sure where else to put it).