### PR TITLE
Use Elixir as compiled for OTP 27

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-elixir 1.18.3
+elixir 1.18.3-otp-27
 erlang 27.3
 zig 0.14.0


### PR DESCRIPTION
Without the -otp-27, Elixir is compiled for an earlier version of OTP.
It doesn't look like it currently matters for this project, but it could
in the future.
