### PR TITLE
validate product name does not have spaces

### DIFF
--- a/lib/nerves_hub_cli/api/product.ex
+++ b/lib/nerves_hub_cli/api/product.ex
@@ -23,7 +23,8 @@ defmodule NervesHubCLI.API.Product do
   end
 
   @doc """
-  Create a new product.
+  Create a new product. Only allows product names which are nicely formatted (ie, only lowercase,
+  uppercase, numbers, underscores, dashes, and periods)
 
   Verb: POST
   Path: /orgs/:org_name/products
@@ -31,8 +32,14 @@ defmodule NervesHubCLI.API.Product do
   @spec create(String.t(), any(), NervesHubCLI.API.Auth.t()) ::
           {:error, any()} | {:ok, any()}
   def create(org_name, product_name, %Auth{} = auth) do
-    params = %{name: product_name}
-    API.request(:post, path(org_name), params, auth)
+    cond do
+      String.match?(product_name, ~r/^[a-zA-Z0-9_-]+$/) ->
+        params = %{name: product_name}
+        API.request(:post, path(org_name), params, auth)
+
+      true ->
+        {:error, :invalid_name}
+    end
   end
 
   @doc """

--- a/lib/nerves_hub_cli/cli/product.ex
+++ b/lib/nerves_hub_cli/cli/product.ex
@@ -186,6 +186,11 @@ defmodule NervesHubCLI.CLI.Product do
       {:ok, %{"data" => %{} = _product}} ->
         Shell.info("Product '#{name}' created.")
 
+      {:error, :invalid_name} ->
+        Shell.error(
+          "Invalid product name. Product name can only contain letters, numbers, dashes and underscores"
+        )
+
       error ->
         Shell.render_error(error)
     end


### PR DESCRIPTION
NervesHub does not handle product names with spaces very well (the product name is used in the request path for API calls). This prevents you from successfully creating a product name with spaces in it.

Addresses #258, #146, #141