### PR TITLE
Fixing reference to uri append path

### DIFF
--- a/lib/nerves_hub_cli/cli/utils.ex
+++ b/lib/nerves_hub_cli/cli/utils.ex
@@ -150,13 +150,13 @@ defmodule NervesHubCLI.CLI.Utils do
 
   Invalid tags raise.
 
-    iex> Mix.NervesHubCLI.Utils.split_tag_string("a, b, c")
+    iex> NervesHubCLI.CLI.Utils.split_tag_string("a, b, c")
     ["a", "b", "c"]
 
-    iex> Mix.NervesHubCLI.Utils.split_tag_string("a space tag, b, c")
+    iex> NervesHubCLI.CLI.Utils.split_tag_string("a space tag, b, c")
     ** (RuntimeError) Tag 'a space tag' should not contain white space
 
-    iex> Mix.NervesHubCLI.Utils.split_tag_string("\\"tag_in_quotes\\"")
+    iex> NervesHubCLI.CLI.Utils.split_tag_string("\\"tag_in_quotes\\"")
     ** (RuntimeError) Tag '\"tag_in_quotes\"' should not contain quotes
 
   """

--- a/test/nerves_hub_cli_test.exs
+++ b/test/nerves_hub_cli_test.exs
@@ -1,5 +1,5 @@
 defmodule NervesHubCLITest do
   use ExUnit.Case
   doctest NervesHubCLI
-  doctest Mix.NervesHubCLI.Utils
+  doctest NervesHubCLI.CLI.Utils
 end


### PR DESCRIPTION
The current minimum version of Elixir is 1.13, but includes depends on `URI.append_path/1` which isn't available until 1.15. This PR checks the Elixir version at runtime and either uses the new API, or uses a version of that implementation copied directly in the source here.

The idea is for this to be used temporarily until the minimum version of Elixir is raised to at least 1.15.

The doc tests were not running for us, so we also fixed those while driving by.