### PR TITLE
Add support for NervesCloud env vars, and a few other bits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,24 +17,5 @@
 
 /tmp
 
-/.elixir_ls
-
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
-
-# Also ignore archive artifacts (built via "mix archive.build").
-*.ez
-
-# Ignore package tarball (built via "mix hex.build").
-nerves_hub_cli-*.tar
-
-# Ignore any dev home_dir
-/.nerves-hub/
-
-# Ignore any test home_dir
-/test/.nerves-hub
-
-
-# Ignore any nerves-hub certificates
-/nerves-hub
-/*.pem

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# NervesHubCLI
+# NervesCloud and NervesHub CLI
 
-The recommended CLI tool for working with [NervesHub](https://www.nerves-hub.org) and
-[NervesCloud](https://nervescloud.com) from the command-line.
+The recommended CLI tool for working with [NervesCloud](https://nervescloud.com) and self-hosted [NervesHub](https://github.com/nerves-hub/nerves_hub_web) platforms.
 
 Features include:
 
@@ -62,65 +61,45 @@ $ nh help
 $ nh help device
 ```
 
-Burritos magic is how it creates a platform specific Erlang release, compresses it into a binary, which is then
-extracted to a directory managed by Burrito when the binary is executed for the first time.
+## Connecting to your NervesHub
 
-Subsquent use of the binary will proxy the commands to the extracted release, invisible to the user.
+When using the CLI, the default URI points to [NervesCloud](https://nervescloud.com) : `https://manage.nervescloud.com`.  
 
-
-## Connecting to NervesHub
-
-NervesHubCLI must be configured to connect to your chosen NervesHub host.
-
-To configure the NervesHub URI, run:
+To configure a different URI you can use:
 
 ```sh
-$ nh config set uri "https://my.nerveshub.instance/"
+$ nh config set uri "https://my.selfhosted.instance/"
 ```
 
-and for [NervesCloud](https://nervescloud.com):
+Finally, you need to authorize your account with the choosen platform by running:
 
 ```sh
-$ nh config set uri "https://manage.nervescloud.com/"
-```
-
-Finally, you need to authorize your account on the NervesHub instance by running:
-
-```sh
-$ nh user whoami
 $ nh user auth
 ```
 
 
 ## Environment variables
 
-`NervesHubCLI` may be configured using environment variables to simplify
-automation. The following variables are available:
+The CLI can be configured using environment variables to simplify automation. 
 
-* `NERVES_HUB_TOKEN` (or `NH_TOKEN`) - Token used to authenticate API requests
-* `NERVES_HUB_CERT` - Certificate contents for authenticating with NervesHub
-* `NERVES_HUB_KEY`  - The private key associated with `NERVES_HUB_CERT`
-* `NERVES_HUB_ORG`  - NervesHub organization to use
-* `NERVES_HUB_PRODUCT`  - NervesHub product to use
-* `NERVES_HUB_FW_PRIVATE_KEY` - Fwup signing private key
-* `NERVES_HUB_FW_PUBLIC_KEY`  - Fwup signing public key
-* `NERVES_HUB_HOME` - NervesHub CLI data directory (defaults to `~/.nerves-hub`)
-* `NERVES_HUB_URI` - NervesHub API host, port, scheme (all in one)
-* `NERVES_HUB_HOST` - NervesHub API endpoint IP address or hostname
-* `NERVES_HUB_PORT` - NervesHub API endpoint port
-* `NERVES_HUB_SCHEME` - NervesHub API endpoint scheme
-* `NERVES_HUB_NON_INTERACTIVE` - Force all yes/no user interaction to be yes
+The following variables are available:
 
+* `NERVES_CLOUD_TOKEN`/`NERVES_HUB_TOKEN` - Token used to authenticate API requests
+* `NERVES_CLOUD_ORG`/`NERVES_HUB_ORG` - Organization used for API requests
+* `NERVES_CLOUD_PRODUCT`/`NERVES_HUB_PRODUCT` - Product to used for API requests
+* `NERVES_CLOUD_FW_PRIVATE_KEY`/`NERVES_HUB_FW_PRIVATE_KEY` - Private key used for signing firmware
+* `NERVES_CLOUD_FW_PUBLIC_KEY`/`NERVES_HUB_FW_PUBLIC_KEY` - Public key used for verifying firmware
+* `NERVES_CLOUD_DATA_DIR`/`NERVES_HUB_DATA_DIR` - Directory used for storing config and signing keys (defaults to `~/.nerves-cloud`/`~/.nerves-hub`)
+* `NERVES_CLOUD_URI`/`NERVES_HUB_URI` - Platform URI (defaults to `https://manage.nervescloud.com`)
+* `NERVES_CLOUD_NON_INTERACTIVE`/`NERVES_HUB_NON_INTERACTIVE` - Force all yes/no user interaction to be yes
 
 
 ## Uninstalling the CLI
 
-When you uninstall the NervesHubCLI it is highly recommended to run:
+When you uninstall the CLI, it's highly recommended to run:
 
 ```
 $ nh maintenance uninstall
 ```
-
-which tells Burrito to remove the cached contents.
 
 Once you have run the above command you can safely delete the `nh` binary.

--- a/lib/nerves_hub_cli.ex
+++ b/lib/nerves_hub_cli.ex
@@ -12,9 +12,10 @@ defmodule NervesHubCLI do
     to_string(hostname)
   end
 
-  @spec home_dir() :: String.t()
-  def home_dir() do
-    override_dir = System.get_env("NERVES_HUB_HOME")
+  @spec data_dir() :: String.t()
+  def data_dir() do
+    override_dir =
+      System.get_env("NERVES_CLOUD_DATA_DIR") || System.get_env("NERVES_HUB_DATA_DIR")
 
     if override_dir == nil or override_dir == "" do
       Path.expand("~/.nerves-hub")

--- a/lib/nerves_hub_cli/api.ex
+++ b/lib/nerves_hub_cli/api.ex
@@ -153,7 +153,9 @@ defmodule NervesHubCLI.API do
   end
 
   defp progress?() do
-    System.get_env("NERVES_LOG_DISABLE_PROGRESS_BAR") == nil
+    System.get_env("NERVES_LOG_DISABLE_PROGRESS_BAR") == nil &&
+      System.get_env("NERVES_HUB_NON_INTERACTIVE") in [nil, ""] &&
+      System.get_env("DEBIAN_FRONTEND") != "noninteractive"
   end
 
   defp ca_certs do

--- a/lib/nerves_hub_cli/api.ex
+++ b/lib/nerves_hub_cli/api.ex
@@ -1,5 +1,7 @@
 defmodule NervesHubCLI.API do
   @moduledoc false
+  alias NervesHubCLI.CLI.Utils
+
   require Logger
 
   @file_chunk 4096
@@ -14,17 +16,10 @@ defmodule NervesHubCLI.API do
   """
   @spec endpoint() :: String.t()
   def endpoint() do
-    if server = System.get_env("NERVES_HUB_URI") || NervesHubCLI.Config.get(:uri) do
-      URI.parse(server)
-      |> append_path("/api")
-      |> URI.to_string()
-    else
-      scheme = System.get_env("NERVES_HUB_SCHEME")
-      host = System.get_env("NERVES_HUB_HOST")
-      port = get_env_as_integer("NERVES_HUB_PORT")
-
-      %URI{scheme: scheme, host: host, port: port, path: "/api"} |> URI.to_string()
-    end
+    NervesHubCLI.Config.uri()
+    |> URI.parse()
+    |> append_path("/api")
+    |> URI.to_string()
   end
 
   def request(:get, path, params) when is_map(params) do
@@ -59,7 +54,7 @@ defmodule NervesHubCLI.API do
       |> Stream.each(fn chunk ->
         Agent.update(pid, fn sent ->
           size = sent + byte_size(chunk)
-          if progress?(), do: put_progress(size, content_length)
+          if Utils.interactive?(), do: put_progress(size, content_length)
           size
         end)
       end)
@@ -113,26 +108,37 @@ defmodule NervesHubCLI.API do
   defp headers(_), do: []
 
   defp opts() do
-    ssl_options =
-      [
+    default_opts = [
+      recv_timeout: 60_000,
+      protocols: [:http1],
+      timeout: 300_000
+    ]
+
+    if ssl?() do
+      ssl_options = [
         verify: :verify_peer,
         server_name_indication: server_name_indication(),
         cacerts: ca_certs(),
         customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
       ]
 
-    [
-      ssl_options: ssl_options,
-      recv_timeout: 60_000,
-      protocols: [:http1],
-      timeout: 300_000
-    ]
+      default_opts ++ [ssl_options: ssl_options]
+    else
+      default_opts
+    end
+  end
+
+  defp ssl?() do
+    endpoint()
+    |> URI.parse()
+    |> then(& &1.host)
+    |> String.starts_with?("https")
   end
 
   defp server_name_indication do
-    server = System.get_env("NERVES_HUB_URI") || NervesHubCLI.Config.get(:uri)
-
-    URI.parse(server).host
+    endpoint()
+    |> URI.parse()
+    |> then(& &1.host)
     |> to_charlist()
   end
 
@@ -152,21 +158,8 @@ defmodule NervesHubCLI.API do
     trunc(bytes / 1024 / 1024)
   end
 
-  defp progress?() do
-    System.get_env("NERVES_LOG_DISABLE_PROGRESS_BAR") == nil &&
-      System.get_env("NERVES_HUB_NON_INTERACTIVE") in [nil, ""] &&
-      System.get_env("DEBIAN_FRONTEND") != "noninteractive"
-  end
-
   defp ca_certs do
     :public_key.cacerts_get()
-  end
-
-  defp get_env_as_integer(str) do
-    case System.get_env(str) do
-      nil -> nil
-      value -> String.to_integer(value)
-    end
   end
 
   defmodule VendoredURI do

--- a/lib/nerves_hub_cli/cli/deployment.ex
+++ b/lib/nerves_hub_cli/cli/deployment.ex
@@ -9,7 +9,7 @@ defmodule NervesHubCLI.CLI.Deployment do
   ### Command-line options
 
     * `--product` - (Optional) Only show deployments for one product.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
 
   ## create

--- a/lib/nerves_hub_cli/cli/device.ex
+++ b/lib/nerves_hub_cli/cli/device.ex
@@ -20,7 +20,7 @@ defmodule NervesHubCLI.CLI.Device do
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
     * `--identifier` - (Optional) The device identifier
     * `--description` - (Optional) The description of the device
@@ -53,7 +53,7 @@ defmodule NervesHubCLI.CLI.Device do
     * `--csv` - Path to a CSV file
 
     * `--product` - (Optional) The product name.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
 
   ## update
@@ -69,7 +69,7 @@ defmodule NervesHubCLI.CLI.Device do
   ### Command-line options
 
   * `--product` - (Optional) The product name.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
   * `--identifier` - (Optional) Only show device matching an identifier
   * `--description` - (Optional) Only show devices matching a description
@@ -89,27 +89,6 @@ defmodule NervesHubCLI.CLI.Device do
 
       nh device delete DEVICE_IDENTIFIER
 
-  ## burn
-
-  Combine a firmware image with NervesHub provisioning information and burn the
-  result to an attached MicroSD card or file. This requires that the device
-  was already created. Calling burn without passing command-line options will
-  generate a new cert pair for the device. The command will end with calling
-  mix firmware.burn.
-
-      nh device burn DEVICE_IDENTIFIER
-
-  ### Command-line options
-
-    * `--product` - (Optional) The product name.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
-      the global configuration via `nerves_hub config set product "product_name"`
-    * `--cert` - (Optional) A path to an existing device certificate
-    * `--key` - (Optional) A path to an existing device private key
-    * `--path` - (Optional) The path to put the device certificates
-    * `--firmware` - (Optional) The path to the fw file to use. Defaults to
-      `<image_path>/<otp_app>.fw`
-
   ## cert list
 
   List all certificates for a device.
@@ -119,7 +98,7 @@ defmodule NervesHubCLI.CLI.Device do
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
 
   ## cert create
@@ -137,7 +116,7 @@ defmodule NervesHubCLI.CLI.Device do
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
     * `--path` - (Optional) A local location for storing certificates
     * `--signer-cert` - (required) Path to the signer certificate
@@ -153,7 +132,7 @@ defmodule NervesHubCLI.CLI.Device do
   ### Command-line options
 
     * `--product` - (Optional) The product name.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
 
   ## script list
@@ -235,9 +214,6 @@ defmodule NervesHubCLI.CLI.Device do
       ["delete", identifier] ->
         delete(org, product, identifier)
 
-      ["burn", identifier] ->
-        burn(identifier, opts)
-
       ["cert", "list", device] ->
         cert_list(org, product, device)
 
@@ -271,7 +247,6 @@ defmodule NervesHubCLI.CLI.Device do
       nh device create
       nh device update KEY VALUE
       nh device delete DEVICE_IDENTIFIER
-      nh device burn DEVICE_IDENTIFIER
       nh device cert list DEVICE_IDENTIFIER
       nh device cert create DEVICE_IDENTIFIER
       nh device cert import DEVICE_IDENTIFIER CERT_PATH
@@ -402,53 +377,6 @@ defmodule NervesHubCLI.CLI.Device do
     end
   end
 
-  @spec burn(String.t(), keyword()) :: :ok
-  def burn(identifier, opts) do
-    path = opts[:path] || NervesHubCLI.home_dir()
-    cert_path = opts[:cert]
-    key_path = opts[:key]
-
-    {cert_path, key_path} =
-      if key_path == nil and cert_path == nil do
-        cert_path = Path.join(path, identifier <> "-cert.pem")
-        key_path = Path.join(path, identifier <> "-key.pem")
-
-        unless File.exists?(key_path) and File.exists?(cert_path) do
-          Shell.raise("""
-            A private key and certificate for #{identifier}
-            does not exists at path #{path}.
-
-            To generate certificates for #{identifier}
-
-              nh device cert create #{identifier}
-
-          """)
-        end
-
-        {cert_path, key_path}
-      else
-        if key_path == nil or cert_path == nil do
-          Shell.raise("Must specify both --key and --cert")
-        end
-
-        {cert_path, key_path}
-      end
-
-    Shell.info("Burning firmware")
-    System.put_env("NERVES_SERIAL_NUMBER", identifier)
-    System.put_env("NERVES_HUB_CERT", File.read!(cert_path))
-    System.put_env("NERVES_HUB_KEY", File.read!(key_path))
-
-    burn_args =
-      opts
-      |> Keyword.take([:firmware])
-      |> OptionParser.to_argv()
-
-    System.cmd("mix", ["burn" | burn_args])
-
-    :ok
-  end
-
   @spec cert_list(String.t(), String.t(), String.t()) :: :ok
   def cert_list(org, product, identifier) do
     auth = Shell.request_auth()
@@ -469,7 +397,7 @@ defmodule NervesHubCLI.CLI.Device do
         ) :: :ok
   def cert_create(org, identifier, opts) do
     Shell.info("Creating certificate for #{identifier}")
-    path = opts[:path] || NervesHubCLI.home_dir()
+    path = opts[:path] || NervesHubCLI.data_dir()
     File.mkdir_p!(path)
 
     key = X509.PrivateKey.new_ec(:secp256r1)

--- a/lib/nerves_hub_cli/cli/firmware.ex
+++ b/lib/nerves_hub_cli/cli/firmware.ex
@@ -13,7 +13,7 @@ defmodule NervesHubCLI.CLI.Firmware do
   ### Command-line options
 
     * `--product` - (Optional) The product name to publish the firmware to.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
 
     * `--deploy` - (Optional) The name of a deployment to update following
@@ -29,7 +29,7 @@ defmodule NervesHubCLI.CLI.Firmware do
   ### Command-line options
 
     * `--product` - (Optional) The product name to publish the firmware to.
-      This defaults to the NERVES_HUB_PRODUCT environment variable (if set) or
+      This defaults to the NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT environment variable (if set) or
       the global configuration via `nerves_hub config set product "product_name"`
 
 
@@ -55,6 +55,7 @@ defmodule NervesHubCLI.CLI.Firmware do
   """
 
   import NervesHubCLI.CLI.Utils
+
   alias NervesHubCLI.Cmd
   alias NervesHubCLI.CLI.Shell
 
@@ -177,11 +178,7 @@ defmodule NervesHubCLI.CLI.Firmware do
   end
 
   defp publish(firmware, org, product, opts) do
-    if (System.get_env("NERVES_HUB_FW_PRIVATE_KEY_PATH") &&
-          System.get_env("NERVES_HUB_FW_PUBLIC_KEY_PATH")) ||
-         (System.get_env("NERVES_HUB_FW_PRIVATE_KEY") &&
-            System.get_env("NERVES_HUB_FW_PUBLIC_KEY")) ||
-         opts[:key] do
+    if firmware_signing_key_paths?() || firmware_signing_keys?() || opts[:key] do
       sign(firmware, org, opts)
     end
 

--- a/lib/nerves_hub_cli/cli/key.ex
+++ b/lib/nerves_hub_cli/cli/key.ex
@@ -226,7 +226,7 @@ defmodule NervesHubCLI.CLI.Key do
   end
 
   def export(key, org, opts) do
-    path = opts[:path] || NervesHubCLI.home_dir()
+    path = opts[:path] || NervesHubCLI.data_dir()
 
     with :ok <- File.mkdir_p(path),
          {:ok, public_key, private_key} <- Shell.request_keys(org, key, show_key_info: false),

--- a/lib/nerves_hub_cli/cli/shell.ex
+++ b/lib/nerves_hub_cli/cli/shell.ex
@@ -1,4 +1,5 @@
 defmodule NervesHubCLI.CLI.Shell do
+  alias NervesHubCLI.Config
   alias NervesHubCLI.CLI.Shell
   alias NervesHubCLI.CLI.Utils
 
@@ -53,8 +54,7 @@ defmodule NervesHubCLI.CLI.Shell do
 
   @spec prompt(String.t()) :: String.t()
   def prompt(message) do
-    if System.get_env("DEBIAN_FRONTEND") == "noninteractive" ||
-         System.get_env("NERVES_HUB_NON_INTERACTIVE") do
+    if Utils.noninteractive?() do
       Shell.raise("\nCouldn't determine firmware path, please specify it manually.")
     else
       IO.gets(message <> " ")
@@ -72,8 +72,7 @@ defmodule NervesHubCLI.CLI.Shell do
 
   @spec yes?(String.t()) :: boolean()
   def yes?(message) do
-    System.get_env("DEBIAN_FRONTEND") == "noninteractive" ||
-      System.get_env("NERVES_HUB_NON_INTERACTIVE") ||
+    Utils.interactive?() &&
       IO.ANSI.format([message, :yellow, " yN "])
       |> IO.gets()
       |> then(fn resp ->
@@ -83,7 +82,7 @@ defmodule NervesHubCLI.CLI.Shell do
 
   @spec request_auth() :: NervesHubCLI.API.Auth.t() | nil
   def request_auth() do
-    if token = Utils.token() do
+    if token = Config.token() do
       %NervesHubCLI.API.Auth{token: token}
     else
       __MODULE__.raise("You are not authenticated")
@@ -97,25 +96,19 @@ defmodule NervesHubCLI.CLI.Shell do
   def request_keys(org, name, opts \\ []) do
     show_key_info = Keyword.get(opts, :show_key_info, true)
 
-    env_pub_key_path = System.get_env("NERVES_HUB_FW_PUBLIC_KEY_PATH")
-    env_priv_key_path = System.get_env("NERVES_HUB_FW_PRIVATE_KEY_PATH")
-
-    env_pub_key = System.get_env("NERVES_HUB_FW_PUBLIC_KEY")
-    env_priv_key = System.get_env("NERVES_HUB_FW_PRIVATE_KEY")
-
     cond do
       not is_nil(name) ->
         show_key_info && info("  with key #{name}\n")
         key_password = password_get("Local signing key password for '#{name}': ")
         NervesHubCLI.Key.get(org, name, key_password)
 
-      env_pub_key_path != nil and env_priv_key_path != nil ->
+      Utils.firmware_signing_key_paths?() ->
         show_key_info && info("  using public and private key file paths from the environment\n")
-        {:ok, :path, {env_pub_key_path, env_priv_key_path}}
+        {:ok, :path, Utils.firmware_signing_key_paths()}
 
-      env_pub_key != nil and env_priv_key != nil ->
+      Utils.firmware_signing_keys?() ->
         show_key_info && info("  using public and private keys from the environment\n")
-        {:ok, :data, {env_pub_key, env_priv_key}}
+        {:ok, :data, Utils.firmware_signing_keys()}
 
       true ->
         Enum.join(
@@ -124,6 +117,8 @@ defmodule NervesHubCLI.CLI.Shell do
             "",
             "  Please specify the firmware signing key with either:",
             "    --key key_name",
+            "    or NERVES_CLOUD_FW_PUBLIC_KEY_PATH and NERVES_CLOUD_FW_PRIVATE_KEY_PATH env vars",
+            "    or NERVES_CLOUD_FW_PUBLIC_KEY and NERVES_CLOUD_FW_PRIVATE_KEY env vars",
             "    or NERVES_HUB_FW_PUBLIC_KEY_PATH and NERVES_HUB_FW_PRIVATE_KEY_PATH env vars",
             "    or NERVES_HUB_FW_PUBLIC_KEY and NERVES_HUB_FW_PRIVATE_KEY env vars"
           ],

--- a/lib/nerves_hub_cli/cli/shell.ex
+++ b/lib/nerves_hub_cli/cli/shell.ex
@@ -53,8 +53,13 @@ defmodule NervesHubCLI.CLI.Shell do
 
   @spec prompt(String.t()) :: String.t()
   def prompt(message) do
-    IO.gets(message <> " ")
-    |> String.trim()
+    if System.get_env("DEBIAN_FRONTEND") == "noninteractive" ||
+         System.get_env("NERVES_HUB_NON_INTERACTIVE") do
+      Shell.raise("\nCouldn't determine firmware path, please specify it manually.")
+    else
+      IO.gets(message <> " ")
+      |> String.trim()
+    end
   end
 
   @spec prompt(String.t(), String.t()) :: String.t()

--- a/lib/nerves_hub_cli/cli/user.ex
+++ b/lib/nerves_hub_cli/cli/user.ex
@@ -11,10 +11,10 @@ defmodule NervesHubCLI.CLI.User do
   presented in each request.
 
   You can use `nh user auth` to authenticate with NervesHub,
-  saving the token locally in your local config found in `$NERVES_HUB_HOME`
+  saving the token locally in your local config found in `$NERVES_CLOUD_DATA_DIR` / `$NERVES_HUB_DATA_DIR`
 
-  Or this token can be manually supplied with the `NERVES_HUB_TOKEN` environment
-  variable. This approach is recommended when using CLI in CI/CD systems.
+  Or this token can be manually supplied with the `NERVES_CLOUD_TOKEN` or `NERVES_HUB_TOKEN` environment
+  variables. This approach is recommended when using CLI in CI/CD systems.
 
   # Available commands
 

--- a/lib/nerves_hub_cli/cli/utils.ex
+++ b/lib/nerves_hub_cli/cli/utils.ex
@@ -10,9 +10,7 @@ defmodule NervesHubCLI.CLI.Utils do
     # - global config, which was set via `nerves_hub config set product "my_product_name"`
     # - fetch list from API and suggest available products
     # - raise with error message
-    product =
-      Keyword.get(opts, :product) || System.get_env("NERVES_HUB_PRODUCT") || Config.get(:product) ||
-        suggest_product(org)
+    product = Config.product(opts) || suggest_product(org)
 
     Shell.info([:cyan, "Product:        ", :reset, "#{product}"])
     Shell.info("")
@@ -51,9 +49,9 @@ defmodule NervesHubCLI.CLI.Utils do
 
         --product product_name
 
-      By setting the environment variable NERVES_HUB_PRODUCT
+      By setting the environment variable NERVES_CLOUD_PRODUCT or NERVES_HUB_PRODUCT
 
-        export NERVES_HUB_PRODUCT=product_name
+        export NERVES_CLOUD_PRODUCT=product_name
 
       Via global configuration (this applies to all projects)
 
@@ -83,7 +81,6 @@ defmodule NervesHubCLI.CLI.Utils do
 
       Finally, you need to authorize your account on the NervesHub instance by running:
 
-        nh user whoami
         nh user auth
       """)
     end
@@ -100,7 +97,7 @@ defmodule NervesHubCLI.CLI.Utils do
     # - global config, which was set via `nerves_hub config set org "my_product_name"`
     # - raise with error message
     org =
-      Keyword.get(opts, :org) || System.get_env("NERVES_HUB_ORG") || Config.get(:org) ||
+      Config.org(opts) ||
         Shell.raise("""
         Cound not determine organization
 
@@ -110,9 +107,9 @@ defmodule NervesHubCLI.CLI.Utils do
 
             --org org_name
 
-          By setting the environment variable NERVES_HUB_ORG
+          By setting the environment variable NERVES_CLOUD_ORG or NERVES_HUB_ORG
 
-            export NERVES_HUB_ORG=org_name
+            export NERVES_CLOUD_ORG=org_name
 
           Via global configuration (this applies to all projects)
 
@@ -218,15 +215,6 @@ defmodule NervesHubCLI.CLI.Utils do
   end
 
   @doc """
-  Get User Access Token for use with the session
-  """
-  def token(opts \\ []) do
-    opts[:token] ||
-      System.get_env("NERVES_HUB_TOKEN") || System.get_env("NH_TOKEN") ||
-      Config.get(:token)
-  end
-
-  @doc """
   Derive likely current firmware
   """
   def firmware_path() do
@@ -249,6 +237,61 @@ defmodule NervesHubCLI.CLI.Utils do
             Shell.prompt("\nFirmware path:")
         end
     end
+  end
+
+  def interactive?() do
+    System.get_env("NERVES_LOG_DISABLE_PROGRESS_BAR") == nil &&
+      System.get_env("NERVES_CLOUD_NON_INTERACTIVE") == nil &&
+      System.get_env("NERVES_HUB_NON_INTERACTIVE") == nil &&
+      System.get_env("DEBIAN_FRONTEND") != "noninteractive" &&
+      System.get_env("CI") == nil
+  end
+
+  def noninteractive?(), do: !interactive?()
+
+  def firmware_signing_key_paths?() do
+    all?(["NERVES_CLOUD_FW_PUBLIC_KEY_PATH", "NERVES_CLOUD_FW_PRIVATE_KEY_PATH"]) ||
+      all?(["NERVES_HUB_FW_PUBLIC_KEY_PATH", "NERVES_HUB_FW_PRIVATE_KEY_PATH"])
+  end
+
+  def firmware_signing_keys?() do
+    all?(["NERVES_CLOUD_FW_PUBLIC_KEY", "NERVES_CLOUD_FW_PRIVATE_KEY"]) ||
+      all?(["NERVES_HUB_FW_PUBLIC_KEY", "NERVES_HUB_FW_PRIVATE_KEY"])
+  end
+
+  def firmware_signing_key_paths() do
+    cond do
+      all?(["NERVES_CLOUD_FW_PUBLIC_KEY_PATH", "NERVES_CLOUD_FW_PRIVATE_KEY_PATH"]) ->
+        {System.get_env("NERVES_CLOUD_FW_PUBLIC_KEY_PATH"),
+         System.get_env("NERVES_CLOUD_FW_PRIVATE_KEY_PATH")}
+
+      all?(["NERVES_HUB_FW_PUBLIC_KEY_PATH", "NERVES_HUB_FW_PRIVATE_KEY_PATH"]) ->
+        {System.get_env("NERVES_HUB_FW_PUBLIC_KEY_PATH"),
+         System.get_env("NERVES_HUB_FW_PRIVATE_KEY_PATH")}
+
+      true ->
+        raise "No firmware signing key paths configured in via environment variables"
+    end
+  end
+
+  def firmware_signing_keys() do
+    cond do
+      all?(["NERVES_CLOUD_FW_PUBLIC_KEY", "NERVES_CLOUD_FW_PRIVATE_KEY"]) ->
+        {System.get_env("NERVES_CLOUD_FW_PUBLIC_KEY"),
+         System.get_env("NERVES_CLOUD_FW_PRIVATE_KEY")}
+
+      all?(["NERVES_HUB_FW_PUBLIC_KEY", "NERVES_HUB_FW_PRIVATE_KEY"]) ->
+        {System.get_env("NERVES_HUB_FW_PUBLIC_KEY"), System.get_env("NERVES_HUB_FW_PRIVATE_KEY")}
+
+      true ->
+        raise "No firmware signing keys configured in via environment variables"
+    end
+  end
+
+  defp all?(env_vars) do
+    env_vars
+    |> Enum.map(&System.get_env(&1))
+    |> Enum.all?(&(&1 not in [nil, ""]))
   end
 
   defp check_valid_tag(tag) do

--- a/lib/nerves_hub_cli/cli/utils.ex
+++ b/lib/nerves_hub_cli/cli/utils.ex
@@ -246,7 +246,7 @@ defmodule NervesHubCLI.CLI.Utils do
 
           [] ->
             Shell.info("Target: host (cannot determine firmware path)")
-            Shell.prompt("Firmware path:")
+            Shell.prompt("\nFirmware path:")
         end
     end
   end

--- a/lib/nerves_hub_cli/config.ex
+++ b/lib/nerves_hub_cli/config.ex
@@ -1,6 +1,36 @@
 defmodule NervesHubCLI.Config do
   @config "nerves-hub.config"
 
+  @default_uri "https://manage.nervescloud.com"
+
+  def uri do
+    System.get_env("NERVES_HUB_URI") || get(:uri) || @default_uri
+  end
+
+  @doc """
+  Get User Access Token for use with the session
+  """
+  def token(opts \\ []) do
+    Keyword.get(opts, :token) ||
+      System.get_env("NERVES_CLOUD_TOKEN") ||
+      System.get_env("NERVES_HUB_TOKEN") ||
+      get(:token)
+  end
+
+  def product(opts \\ []) do
+    Keyword.get(opts, :product) ||
+      System.get_env("NERVES_CLOUD_PRODUCT") ||
+      System.get_env("NERVES_HUB_PRODUCT") ||
+      get(:product)
+  end
+
+  def org(opts \\ []) do
+    Keyword.get(opts, :org) ||
+      System.get_env("NERVES_CLOUD_ORG") ||
+      System.get_env("NERVES_HUB_ORG") ||
+      get(:org)
+  end
+
   def delete(key) do
     read()
     |> Map.delete(key)
@@ -28,14 +58,14 @@ defmodule NervesHubCLI.Config do
   end
 
   defp write(config) do
-    unless File.dir?(NervesHubCLI.home_dir()) do
-      File.mkdir_p!(NervesHubCLI.home_dir())
+    unless File.dir?(NervesHubCLI.data_dir()) do
+      File.mkdir_p!(NervesHubCLI.data_dir())
     end
 
     File.write(file(), :erlang.term_to_binary(config))
   end
 
   defp file do
-    Path.join(NervesHubCLI.home_dir(), @config)
+    Path.join(NervesHubCLI.data_dir(), @config)
   end
 end

--- a/lib/nerves_hub_cli/key.ex
+++ b/lib/nerves_hub_cli/key.ex
@@ -120,7 +120,7 @@ defmodule NervesHubCLI.Key do
   def public_ext(), do: @public_ext
 
   defp data_dir(org) do
-    Path.join([NervesHubCLI.home_dir(), "keys", org])
+    Path.join([NervesHubCLI.data_dir(), "keys", org])
   end
 
   # Used to validate a fwup key import.


### PR DESCRIPTION
- Remove `nh device burn` as this is too specific to cert device auth, and requires further customization from the user
- Change `NERVES_HUB_HOME` to `NERVES_HUB_DATA_DIR`, which is more descriptive and correct.
- Use `https://manage.nervescloud.com` as the default URI
- Support http API usage
- If the `CI` env var is present, enable `noninteractive` mode.